### PR TITLE
PLATUI-200 Implement Twirl for hmrc-frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 
 logs
-project/project
 project/target
 target
 lib_managed

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,45 @@
+style = defaultWithAlign
+maxColumn = 120
+lineEndings = unix
+importSelectors = singleLine
+
+project {
+  git = true
+}
+
+align = most
+
+align {
+  tokens = [ {code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%", "should", "shouldBe", "must" ]
+  arrowEnumeratorGenerator = true
+  openParenCallSite = false
+  openParenDefnSite = false
+}
+
+binPack {
+  parentConstructors = false
+}
+
+continuationIndent {
+  callSite = 2
+  defnSite = 2
+}
+
+newlines {
+  penalizeSingleSelectMultiArgList = false
+  sometimesBeforeColonInMethodReturnType = true
+}
+
+rewrite {
+  rules = [RedundantBraces, RedundantParens, AsciiSortImports]
+  redundantBraces {
+    maxLines = 100
+    includeUnitMethods = true
+    stringInterpolation = true
+  }
+}
+
+spaces {
+  inImportCurlyBraces = false
+  beforeContextBoundColon = false
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,183 @@
-
 # play-frontend-hmrc
 
-This is a placeholder README.md for a new repository
+This library provides a Play/Twirl implementation of `hmrc-frontend`.
 
-### License
+[hmrc-frontend](https://github.com/hmrc/hmrc-frontend) contains the code and documentation for patterns specifically designed for HMRC.
+
+[GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) and the [GOV.UK Design System](https://design-system.service.gov.uk/) contains the code and documentation for design patterns designed to be used by all government departments.
+
+The two sets of code and documentation are separate but used together.
+
+See [HMRC Design Patterns](https://design.tax.service.gov.uk/hmrc-design-patterns/) for examples of what the design patterns look like and guidance on how to use them in your service.
+
+## Table of Contents
+
+- [Background](#background)
+- [Getting Started](#getting-started)
+- [Usage](#usage)
+- [Dependencies](#dependencies)
+- [Getting Help](#getting-help)
+- [Contributing](#contributing)
+- [Useful Links](#useful-links)
+- [Owning Team Readme](#owning-team-readme)
+- [License](#license)
+
+## Background
+
+This library provides `Twirl` basic building blocks as originally implemented in the [hmrc-frontend](https://github.com/hmrc/hmrc-frontend/)
+library. Additionally, we plan to include more helpers built on top of `Play's` own helpers and the basic components.
+
+## Getting started
+1>  Add [Twirl](https://github.com/hmrc/play-frontend-hmrc/releases) library in the App dependencies.
+```sbt
+//build.sbt for Play 2.5
+libraryDependencies += "uk.gov.hmrc" %% "play-frontend-hmrc" % "x.y.z-play-25"
+//or Play 2.6
+libraryDependencies += "uk.gov.hmrc" %% "play-frontend-hmrc" % "x.y.z-play-26"
+```
+
+2>  Add SASS assets to app/assets/stylesheets in application.scss to inherit / extend hmrc-frontend style assets / elements, e.g.:
+```
+$hmrc-assets-path: "/app-name-here/assets/lib/hmrc-frontend/hmrc/assets/";
+
+@import "lib/hmrc-frontend/hmrc/all";
+
+.app-reference-number {
+  display: block;
+  font-weight: bold;
+}
+```
+
+3>  Add hmrc-frontend routing redirection in app.routes:
+```scala
+->         /hmrc-frontend                      hmrcfrontend.Routes
+```
+
+4>  Add TwirlKeys.templateImports in build.sbt:
+```sbt
+    TwirlKeys.templateImports ++= Seq(
+      "uk.gov.hmrc.hmrcfrontend.views.html.components._"
+    )
+```
+
+5>  You may want to consider mixing in the [play-frontend-govuk](https://github.com/hmrc/play-frontend-govuk/) library as a dependency to use GovukLayout to create standard views out of the box
+```scala
+@govukLayout(
+    pageTitle = pageTitle,
+    headBlock = Some(head()),
+    beforeContentBlock = beforeContentBlock,
+    footerItems = Seq(FooterItem(href = Some("https://govuk-prototype-kit.herokuapp.com/"), text = Some("GOV.UK Prototype Kit v9.1.0"))),
+    bodyEndBlock = Some(scripts()))(contentBlock)
+```
+
+### Using hmrc-frontend Components in Twirl
+
+To use the [hmrc-frontend](https://github.com/hmrc/hmrc-frontend/) `Twirl` [components](https://github.com/hmrc/play-frontend-hmrc/blob/master/src/main/play-26/uk/gov/hmrc/hmrcfrontend/views/html/components/package.scala) 
+and all the [types](https://github.com/hmrc/play-frontend-hmrc/blob/master/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Aliases.scala) needed to construct them, import the following:
+```scala
+@import uk.gov.hmrc.hmrcfrontend.views.html.components._
+```
+
+### Twirl HTML helper methods
+The following import will summon [implicits](https://github.com/hmrc/play-frontend-hmrc/blob/master/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Implicits.scala) that provide extension methods on `Play's` [Html](https://www.playframework.com/documentation/2.6.x/api/scala/play/twirl/api/Html.html) objects.
+This includes HTML trims, pads, indents and handling HTML emptiness.
+```scala
+@import uk.gov.hmrc.hmrcfrontend.views.html.components.implicits._
+```
+
+## Usage
+
+The library is cross-compiled for `Play 2.5` and `Play 2.6`, the main difference between the two versions being that the latter
+supports dependency injection of Twirl templates.
+
+### Play 2.5
+
+The namespace `uk.gov.hmrc.hmrcfrontend.views.html.components` exposes the components' templates as values with the prefix
+`Hmrc`, ex: an `hmrcPageHeading` is available as `HmrcPageHeading`.
+
+Ex: a page heading with a corresponding section
+```scala
+@import uk.gov.hmrc.hmrcfrontend.views.html.components._
+
+@()
+@HmrcPageHeading(PageHeading(
+  text = "Foo",
+  section = Some("Section bar")
+))
+```
+
+### Play 2.6
+
+The same namespace exposes type aliases prefixed with `Hmrc` (ex: the type `HmrcPageHeading`) so that components can be injected into 
+a controller or template. It also exposes values of the same name (ex: `HmrcPageHeading`) if you wish to use the component template directly, 
+though it is preferable to use dependency injection.
+
+Same button using DI:
+```scala
+@import uk.gov.hmrc.hmrcfrontend.views.html.components._
+
+@this(hmrcPageHeading: HmrcPageHeading)
+
+@()
+@hmrcPageHeading(PageHeading(
+  text = "Foo",
+  section = Some("Section bar")
+))
+```
+
+### Example Templates
+
+We intend to provide example templates using the Twirl components through a `Chrome` extension.
+
+This is currently done for govuk-frontend components [here](https://github.com/hmrc/play-frontend-govuk-extension), but yet to be implemented
+for [hmrc-frontend](https://github.com/hmrc/hmrc-frontend/).
+
+With the extension installed, you would then be able to go to the [HMRC Design System](https://design.tax.service.gov.uk/hmrc-design-patterns/), 
+click on a component on the sidebar and see the `Twirl` examples matching the provided `Nunjucks` templates.
+
+## Dependencies
+
+### sbt
+
+The library depends on an `hmrc-frontend` artifact published as a webjar.
+
+```sbt
+"org.webjars.npm" % "hmrc-frontend" % "x.y.z"
+```
+
+We do not currently automate the publishing of the webjar so it has to be manually published from [WebJars](https://www.webjars.org) after an `hmrc-frontend` release.
+
+## Getting help
+
+Please report any issues with this library in Slack at `#event-play-frontend-beta`.
+
+For other issues or wider discussions, please use `#team-plat-ui`.
+
+## Contributing
+
+### Design patterns
+
+If you need a pattern that does not appear in the HMRC Design Patterns, you can [contribute a new one](https://github.com/hmrc/design-patterns/issues/new).
+
+### Features and issues
+
+If you would like to propose a feature or raise an issue with HMRC Frontend, [create an issue](https://github.com/hmrc/hmrc-frontend/issues/new).
+
+You can also create a pull request to contribute to HMRC Frontend. See our [contribution process and guidelines for HMRC Frontend](https://github.com/hmrc/hmrc-frontend/blob/master/CONTRIBUTING.md) before you create a pull request.
+This change will then be available in Twirl once the appropriate upgrade is made in this repository to match that version upgrade.
+
+## Useful Links
+
+- [hmrc-frontend](https://github.com/hmrc/hmrc-frontend/) - reusable Nunjucks HTML components for HMRC design patterns
+- [HMRC Design Patterns](https://design.tax.service.gov.uk/hmrc-design-patterns/) - documentation for the use of `hmrc-frontend` components
+- [play-frontend-govuk](https://github.com/hmrc/play-frontend-govuk/) - Twirl implementation of `govuk-frontend` components
+- [govuk-frontend](https://github.com/alphagov/govuk-frontend/) - reusable Nunjucks HTML components from GOV.UK
+- [GOV.UK Design System](https://design-system.service.gov.uk/components/) - documentation for the use of `govuk-frontend` components
+- [GOV.UK Design System Chrome extension](https://github.com/hmrc/play-frontend-govuk-extension) - `Chrome` extension to add a Twirl tab for each example in the GOV.UK Design System
+
+## Owning team README
+Rationale for code and translation decisions, dependencies, as well as instructions for team members maintaining this repository can be found [here](/docs/maintainers/overview.md).
+
+## License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,170 @@
+import GeneratePlay25Twirl.generatePlay25Templates
+import PlayCrossCompilation.{dependencies, playVersion}
+import de.heikoseeberger.sbtheader.HeaderKey
+import play.sbt.PlayImport.PlayKeys._
+import uk.gov.hmrc.playcrosscompilation.PlayVersion.{Play25, Play26}
+
+val libName = "play-frontend-hmrc"
+
+lazy val playDir =
+  (if (PlayCrossCompilation.playVersion == Play25) "play-25"
+   else "play-26")
+
+lazy val IntegrationTest = config("it") extend Test
+
+lazy val root = Project(libName, file("."))
+  .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtTwirl, SbtArtifactory)
+  .disablePlugins(PlayLayoutPlugin)
+  .configs(IntegrationTest)
+  .settings(
+    name := libName,
+    majorVersion := 0,
+    scalaVersion := "2.11.12",
+    crossScalaVersions := List("2.11.12", "2.12.8"),
+    libraryDependencies ++= libDependencies,
+    dependencyOverrides ++= overrides,
+    resolvers :=
+      Seq(
+        "HMRC Releases" at "https://dl.bintray.com/hmrc/releases",
+        "typesafe-releases" at "http://repo.typesafe.com/typesafe/releases/",
+        "bintray" at "https://dl.bintray.com/webjars/maven"
+      ),
+    TwirlKeys.templateImports := templateImports,
+    PlayCrossCompilation.playCrossCompilationSettings,
+    makePublicallyAvailableOnBintray := true,
+    unmanagedSourceDirectories in Compile += baseDirectory.value / "src/main/twirl",
+    unmanagedSourceDirectories in Test += baseDirectory.value / "src/test/twirl",
+    (sourceDirectories in (Compile, TwirlKeys.compileTemplates)) +=
+      baseDirectory.value / "src" / "main" / playDir / "twirl",
+    (sourceDirectories in (Test, TwirlKeys.compileTemplates)) +=
+      baseDirectory.value / "src" / "test" / playDir / "twirl",
+    (generatePlay25TemplatesTask in Compile) := {
+      val cachedFun: Set[File] => Set[File] =
+        FileFunction.cached(
+          cacheBaseDirectory = streams.value.cacheDirectory / "compile-generate-play-25-templates-task",
+          inStyle            = FilesInfo.lastModified,
+          outStyle           = FilesInfo.exists) { (in: Set[File]) =>
+          println("Generating Play 2.5 templates")
+          generatePlay25Templates(in)
+        }
+
+      val play26TemplatesDir         = baseDirectory.value / "src/main/play-26/twirl"
+      val play26Templates: Set[File] = (play26TemplatesDir ** ("*.scala.html")).get.toSet
+      cachedFun(play26Templates).toSeq
+    },
+    // FIXME: refactor to remove task implementation duplication
+    (generatePlay25TemplatesTask in Test) := {
+      val cachedFun: Set[File] => Set[File] =
+        FileFunction.cached(
+          cacheBaseDirectory = streams.value.cacheDirectory / "test-generate-play-25-templates-task",
+          inStyle            = FilesInfo.lastModified,
+          outStyle           = FilesInfo.exists) { (in: Set[File]) =>
+          println("Generating Play 2.5 test templates")
+          generatePlay25Templates(in)
+        }
+
+      val play26TemplatesDir         = baseDirectory.value / "src/test/play-26/twirl"
+      val play26Templates: Set[File] = (play26TemplatesDir ** ("*.scala.html")).get.toSet
+      cachedFun(play26Templates).toSeq
+    },
+    (TwirlKeys.compileTemplates in Compile) :=
+      ((TwirlKeys.compileTemplates in Compile) dependsOn (generatePlay25TemplatesTask in Compile)).value,
+    (TwirlKeys.compileTemplates in Test) :=
+      ((TwirlKeys.compileTemplates in Test) dependsOn (generatePlay25TemplatesTask in Test)).value,
+    parallelExecution in sbt.Test := false,
+    playMonitoredFiles ++= (sourceDirectories in (Compile, TwirlKeys.compileTemplates)).value,
+    routesGenerator := {
+      if (playVersion == Play25) StaticRoutesGenerator
+      else InjectedRoutesGenerator
+    },
+    HeaderKey.excludes += "fixtures/*/*/*.html",
+    unmanagedResourceDirectories in Test ++= Seq(baseDirectory(_ / "target/web/public/test").value),
+    buildInfoKeys ++= Seq[BuildInfoKey](
+      "playVersion" -> PlayCrossCompilation.playVersion,
+      sources in (Compile, TwirlKeys.compileTemplates)
+    )
+  )
+  .settings(inConfig(IntegrationTest)(itSettings): _*)
+
+lazy val itSettings = Defaults.itSettings ++ Seq(
+  unmanagedSourceDirectories += sourceDirectory.value / playDir,
+  unmanagedResourceDirectories += sourceDirectory.value / playDir / "resources"
+)
+
+lazy val libDependencies: Seq[ModuleID] = dependencies(
+  shared = {
+    import PlayCrossCompilation.playRevision
+
+    val compile = Seq(
+      "com.typesafe.play" %% "play"            % playRevision,
+      "com.typesafe.play" %% "filters-helpers" % playRevision,
+      "org.joda"          % "joda-convert"     % "2.0.2",
+      "org.webjars.npm"   % "hmrc-frontend"    % "1.5.0"
+    )
+
+    val test = Seq(
+      "org.scalatest"                 %% "scalatest"       % "3.0.8",
+      "org.pegdown"                   % "pegdown"          % "1.6.0",
+      "org.jsoup"                     % "jsoup"            % "1.11.3",
+      "com.typesafe.play"             %% "play-test"       % playRevision,
+      "org.scalacheck"                %% "scalacheck"      % "1.14.1",
+      "com.googlecode.htmlcompressor" % "htmlcompressor"   % "1.5.2",
+      "com.github.pathikrit"          %% "better-files"    % "3.8.0",
+      "com.lihaoyi"                   %% "pprint"          % "0.5.3",
+      "org.bitbucket.cowwoc"          % "diff-match-patch" % "1.2",
+      ws
+    ).map(_ % Test)
+
+    compile ++ test
+  },
+  play25 = {
+    val test = Seq(
+      "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1"
+    ).map(_ % Test)
+    test
+  },
+  play26 = {
+    val test = Seq(
+      "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2"
+    )
+    test
+  }
+)
+
+lazy val overrides: Set[ModuleID] = dependencies(
+  play25 = Seq(
+    "com.typesafe.play" %% "twirl-api" % "1.1.1"
+  )
+).toSet
+
+lazy val templateImports: Seq[String] = {
+
+  val allImports = Seq(
+    "_root_.play.twirl.api.Html",
+    "_root_.play.twirl.api.HtmlFormat",
+    "_root_.play.twirl.api.JavaScript",
+    "_root_.play.twirl.api.Txt",
+    "_root_.play.twirl.api.Xml",
+    "play.api.mvc._",
+    "play.api.data._",
+    "play.api.i18n._",
+    "play.api.templates.PlayMagic._",
+    "uk.gov.hmrc.hmrcfrontend.views.html.components.implicits._"
+  )
+
+  val specificImports = PlayCrossCompilation.playVersion match {
+    case Play25 =>
+      Seq(
+        "_root_.play.twirl.api.TemplateMagic._"
+      )
+    case Play26 =>
+      Seq(
+        "_root_.play.twirl.api.TwirlFeatureImports._",
+        "_root_.play.twirl.api.TwirlHelperImports._"
+      )
+  }
+
+  allImports ++ specificImports
+}
+
+lazy val generatePlay25TemplatesTask = taskKey[Seq[File]]("Generate Play 2.5 templates")

--- a/docs/maintainers/overview.md
+++ b/docs/maintainers/overview.md
@@ -1,0 +1,177 @@
+# Repository Maintenance Overview
+
+## Table of Contents
+
+- [Testing](#testing)
+- [Upgrading](#upgrading)
+- [Translation Decisions](#translation-decisions)
+- [Play Versioning](#play-versioning)
+- [Useful Links](#useful-links)
+
+## Testing
+
+### Unit Tests
+
+The suite of unit tests runs against a set of test fixtures with data extracted from [hmrc-frontend's yaml documentation](https://github.com/hmrc/hmrc-frontend/blob/master/src/components/page-heading/page-heading.yaml)
+for each component. The yaml examples are used in `hmrc-frontend`'s own unit test suite. 
+
+The test fixtures are generated from the release of `hmrc-frontend` [used in the library](/README.md#sbt). 
+A script [TODO: document script] generates the fixtures which are manually included in the resources directory under `src/test/resources/fixtures/`.
+The unit tests will pick up the fixtures folder matching the version of `hmrc-frontend` in the dependencies.
+
+_Future work: Unit testing the library using a fixed set of test data provides only very basic coverage. if we can improve 
+the test coverage via generative testing described on the next section, we could discard the test fixtures completely._ 
+
+### Generative Testing
+
+To ensure (as much as possible) that the implemented templates conform to the `hmrc-frontend` templates, we use generative
+testing, via `scalacheck`, to compare the `Twirl` templates output against the `Nunjucks` `hmrc-frontend` templates.
+ 
+The tests run against a `node.js` service used to render the `hmrc-frontend` `Nunjucks` templates,
+so you'll need to install it first.
+To install `node.js` via `nvm` please follow the instructions [here](https://github.com/nvm-sh/nvm#installation-and-update).
+
+To start the service before running integration tests:
+```bash
+git clone git@github.com:hmrc/template-service-spike.git
+
+cd template-service-spike
+
+npm install
+
+npm start
+```
+
+Once the service is started on port 3000, you can run the integration tests:
+```sbt
+sbt it:test
+```
+
+_Note: The integration tests output produces a bit of noise as the library outputs statistics about the generators to check
+the distribution of the test cases. More information about collecting statistics on generators [here](https://github.com/typelevel/scalacheck/blob/master/doc/UserGuide.md#collecting-generated-test-data)._
+
+#### Reproducing Failures (Deterministic Testing)
+In case of a test failure, the test reporter outputs a `org.scalacheck.rng.Seed` encoded in Base-64 that can be passed back to the failing test to reproduce it.
+More information about this feature [here](https://gist.github.com/non/aeef5824b3f681b9cfc141437b16b014).
+
+Ex:
+```scala
+object hmrcPageHeadingIntegrationSpec
+    extends TemplateIntegrationSpec[PageHeading](
+      hmrcComponentName = "hmrcPageHeading", seed = Some("Aw2mVetq64JgBXG2hsqNSIwFnYLc0798R7Ey9XIZr6M=")) // pass the seed and re-run
+```
+
+Upon a test failure, the test reporter prints out a link to a diff file in `HTML` to easily compare the
+markup for the failing test case against the expected markup. The diff is presented as if the `original` file was
+the Twirl template output and the `new` file was the Nunjucks template output (expected result). 
+
+```scala
+Diff between Twirl and Nunjucks outputs (please open diff HTML file in a browser): file:///Users/foo/dev/hmrc/play-frontend-hmrc/target/hmrcPageHeading-diff-2b99bb2a-98d4-48dc-8088-06bfe3008021.html
+```
+
+## Upgrading
+
+[This guide](/docs/maintainers/upgrading.md) describes the process of updating the library when a new version of `hmrc-frontend` is released. 
+
+## Translation Decisions
+
+When writing a new template from an existing `Nunjucks` template it is necessary to make a few translation decisions.
+
+1. validation:
+
+   There is a lack of validation in `Nunjucks` templates to consider when translating `hmrc-frontend` components, but it is important to retain high parity of features.
+  
+   That said, some Twirl components in the library add validation by using `scala` assertions such as 
+ [require](https://www.scala-lang.org/api/current/scala/Predef$.html#require(requirement:Boolean,message:=%3EAny):Unit),
+  which means **`Play` controllers should be handling potential `IllegalArgumentException`** thrown from views.
+
+2. representing required and optional parameters (as documented in the `yaml` for a component in `hmrc-frontend`):
+   
+   Parameters may not always be documented comprehensively as `required` or `optional`, so the disambiguation comes
+   from looking at its usage in the template.
+   We opted to map optional parameters as `Option` types because it is the most natural mapping.
+   
+3. mapping from untyped `Javascript` to `Scala`:
+
+   `Javascript` makes liberal use of boolean-like types, the so called `truthy` and `falsy` values.
+   Special care is needed to translate conditions involving these types correctly.
+   
+   Ex: the following `Nunjucks` snippet where name is a `string` 
+   
+   ```nunjucks
+   {% if params.name %} name="{{ params.name }}"{% endif %}
+   ``` 
+   
+   would not render anything if `name` was `""` since it is a [falsy value](https://developer.mozilla.org/en-US/docs/Glossary/Falsy).
+    
+    It can be mapped to `name: Option[String]` in `Scala` and translated to `Twirl` as: 
+   ```scala
+   @name.filter(_.nonEmpty).map { name => name="@name" }
+   
+   // instead of the following which would render `name=""` 
+   // if name had the value Some("")
+   @name.map { name => name="@name@ }
+   ```
+   
+   Another example is the representation of `Javascript`'s `undefined`, which maps nicely to `Scala`'s `None`.
+   The need to represent `undefined`  sometimes gives rise to unusual types like `Option[List[T]]`.
+   The most correct type here would be `Option[NonEmptyList[T]]` but we opted not to use [refinement types](https://github.com/fthomas/refined) yet.
+
+## Play Versioning
+
+### Play 2.5 / Play 2.6 Cross-Compilation
+
+Regarding [dependency injection for templates](https://www.playframework.com/documentation/2.6.x/ScalaTemplatesDependencyInjection), `Play 2.6`
+introduced breaking changes in the syntax of `Twirl` templates.  For this reason, for every `Play 2.6` template implementing a component, we have
+ to provide an almost identical `Play 2.5-compatible` template, differing only in the dependency injection declaration.
+
+To automate this manual effort, the library uses an `sbt` task to auto-generate the `Play 2.5` templates from the `Play 2.6` ones:
+
+```sbt
+lazy val generatePlay25TemplatesTask = taskKey[Seq[File]]("Generate Play 2.5 templates")
+```
+  
+* this task is a dependency for `twirl-compile-templates` in both `Compile` and `Test` configurations
+* the auto-generated `Play 2.5` templates are not version controlled and should not be edited
+
+### Naming Conventions for Injected Templates in Play 2.6
+
+The automatic generation of `Play 2.5` templates works by stripping out the `@this` declaration
+from a `Play 2.6` template.
+This means that the name of an injected template should match the name of the `Twirl` template file that
+implements it.
+
+Ex: Given a hypothetical new component injecting `HmrcInput` we should name the parameter `hmrcInput`.
+When the `Play 2.5` auto-generated template gets compiled it is able to find the `hmrcInput` object
+that implements the template (defined in the file `hmrcInput.scala.html`).
+```scala
+@this(hmrcInput: HmrcInput)
+
+@()
+@hmrcInput(<params for hmrcInput template>)
+```  
+
+The auto-generated `Play 2.5` template will be:
+```scala
+@()
+@hmrcInput(<params for hmrcInput template>)
+```
+
+`hmrcInput` is the name of the Scala object that implements the compiled `hmrcInput.scala.html` template.
+Had we named the injected component something else, for example `input`, the auto-generated template would fail to compile
+since there is no template named `input.scala.html`.
+
+### Backwards Compatibility in Play 2.6 Templates
+
+Due to the aforementioned differences between the `Twirl` compilers in `Play 2.5` and `Play 2.6` and the auto-generation
+feature, templates should not be written with backwards incompatible features only introduced in `Play 2.6`, such as
+[@if else if](https://github.com/playframework/twirl/issues/33).   
+
+## Useful Links
+- [x-frontend-snapshotter](https://github.com/dorightdigital/x-frontend-snapshotter) - provides static test fixtures for `govuk-frontend` and `hmrc-frontend` components in unit tests
+- [template-service-spike](https://github.com/hmrc/template-service-spike) - service that returns HTML for `govuk-frontend` and `hmrc-frontend` component input parameters in the form of JSON objects - useful for confirming Twirl HTML outputs in integration tests
+- [hmrc-frontend](https://github.com/hmrc/hmrc-frontend/) - reusable Nunjucks HTML components for HMRC design patterns
+- [HMRC Design Patterns](https://design.tax.service.gov.uk/hmrc-design-patterns/) - documentation for the use of `hmrc-frontend` components
+- [govuk-frontend](https://github.com/alphagov/govuk-frontend/) - reusable Nunjucks HTML components from GOV.UK
+- [play-frontend-govuk](https://github.com/hmrc/play-frontend-govuk/) - Twirl implementation of `govuk-frontend` components
+- [GOV.UK Design System](https://design-system.service.gov.uk/components/) - documentation for the use of `govuk-frontend` components

--- a/docs/maintainers/upgrading.md
+++ b/docs/maintainers/upgrading.md
@@ -1,0 +1,79 @@
+# Upgrading play-frontend-govuk
+
+## Basic Steps
+
+1. Go to [webjars.org](https://webjars.org) and add the hmrc-frontend webjar by the following steps:
+ - Click `Add a WebJar`
+ - Select `WebJar Type` as `NPM`
+ - Input `hmrc-frontend` and select the relevant version from the dropdown
+ - Hit `Deploy!`
+2. Bump webjar [dependency](https://github.com/hmrc/hmrc-frontend/tags) for `hmrc-frontend` in `build.sbt`.
+3. Generate and copy fixtures folder to test/resources/fixtures (this won't be necessary when we implement generative testing to increase test coverage).
+   - Follow `Usage` steps in [x-frontend-snapshotter](https://github.com/dorightdigital/x-frontend-snapshotter)
+   - Extract the contents of zip file `test-fixtures-[version-number].tar.gz` created in `target` and copy these to test/resources/fixtures/test-fixtures-[version-number] in this repo.
+4. Run unit tests: `sbt clean test`.
+5. Start integration test dependencies: .
+6. Run integration tests: `sbt clean it:test`.
+7. Compare the two versions of `hmrc-frontend` (outgoing vs incoming) using a diff tool as shown [below](#examining-components-for-failed-tests).
+
+### Comparing Differences
+Since some of the components have dependencies, it is easier to start upgrading by starting from components with no dependencies, or, alternatively, from the components on the bottom of a dependency graph, and work our way up.
+
+We should first look at the components for which tests failed. It is also important to verify that there are no changes in the other components which were not flagged up by failing tests. Again, this situation might be mitigated by increasing test coverage with generative testing.
+
+#### Examining Components for Failed Tests
+ 
+For each failed test, make a diff between the revisions of the affected component for the old hmrc-frontend version and the new one.
+
+Ex: For upgrading from `v1.4.0` to `v1.5.0`: https://github.com/hmrc/hmrc-frontend/compare/v1.4.0...v1.5.0
+
+If there are many moved/renamed files, the heuristics used by git/github to detect such changes may not be accurate, and it is better to use an appropriate diff tool to perform the comparisons.
+
+The important files to diff are the `.yaml` files describing the component's interface and the component's Nunjucks template implementation, usually named `template.njk`.
+
+Ex:
+
+Assuming we setup an appropriate diff tool to use with git, the following example shows how to diff the `.yaml` and `template.njk` files for a given component. Instructions for using `IntelliJ`’s diff and merge tool with `git` can be found [here](https://gist.github.com/rambabusaravanan/1d1902e599c9c680319678b0f7650898).
+
+Given revisions for `hmrc-frontend v1.4.0` of `df35695` and `hmrc-frontend v1.5.0` of `dcfad17`:
+
+```bash
+git difftool df35695:src/components/page-heading/page-heading.yaml dcfad17:src/components/page-heading/page-heading.yaml
+
+git difftool df35695:src/components/page-heading/template.njk dcfad17:src/components/page-heading/template.njk
+```
+
+#### Looking at Other Components
+
+Now we should verify all the other components for differences and improve test coverage in case those differences were
+not detected by the tests.
+
+Ex: For the `file-upload` govuk-frontend component there was a new parameter added but none of the test cases detected the change because 
+of insufficient test coverage.
+```bash
+git diff 8370f97:src/components/file-upload/file-upload.yaml                 3ef1d76:src/govuk/components/file-upload/file-upload.yaml
+```
+
+```diff
+diff --git a/src/components/file-upload/file-upload.yaml b/src/govuk/components/file-upload/file-upload.yaml
+index 51d2d346..713db75d 100644
+--- a/src/components/file-upload/file-upload.yaml
++++ b/src/govuk/components/file-upload/file-upload.yaml
+@@ -11,6 +11,10 @@ params:
+   type: string
+   required: false
+   description: Optional initial value of the input
++- name: describedBy
++  type: string
++  required: false
++  description: One or more element IDs to add to the `aria-describedby` attribute, used to provide additional descriptive information for screenreader users.
+ - name: label
+   type: object
+   required: true
+```
+
+## Useful Links
+- [x-frontend-snapshotter](https://github.com/dorightdigital/x-frontend-snapshotter) - provides static test fixtures for `govuk-frontend` and `hmrc-frontend` components in unit tests
+- [template-service-spike](https://github.com/hmrc/template-service-spike) - service that returns HTML for `govuk-frontend` and `hmrc-frontend` component input parameters in the form of JSON objects - useful for confirming Twirl HTML outputs in integration tests
+- [hmrc-frontend](https://github.com/hmrc/hmrc-frontend/) - reusable Nunjucks HTML components for HMRC design patterns
+- [HMRC Design Patterns](https://design.tax.service.gov.uk/hmrc-design-patterns/) - documentation for the use of `hmrc-frontend` components

--- a/project/GeneratePlay25Twirl.scala
+++ b/project/GeneratePlay25Twirl.scala
@@ -1,0 +1,49 @@
+import sbt._
+
+object GeneratePlay25Twirl {
+
+  /**
+    * Remove '@this' declaration from template and all comments before the template signature
+    * because the Play 2.5 Twirl compiler does not compile if there are comments just before the signature(!)
+    * @param templateFile
+    * @return
+    */
+  def convertToPlay25Template(templateFile: File): String = {
+    val content               = IO.read(templateFile)
+    val thisDeclarationRegex   = """(?s)@this\(.*?\)""" //matches @this declaration
+    val commentRegex           = """(?s)@\*.*?\*@""" //matches Twirl comments
+    val templateSignatureRegex = """@\(""" //matches template signature beginning
+
+    val templateSignatureStart  = templateSignatureRegex.r.findFirstMatchIn(content).map(m => m.start).getOrElse(0)
+    val contentsBeforeSignature = content.substring(0, templateSignatureStart)
+
+    contentsBeforeSignature
+      .replaceAll(thisDeclarationRegex, "")
+      .replaceAll(commentRegex, "")
+      .concat(content.substring(templateSignatureStart))
+  }
+
+  /**
+    * Generates Play 2.5 templates from Play 2.6 ones.
+    * It works on the assumption that the injected template variables in the Play 2.6 templates match the template names
+    * i.e. if a Play 2.6 template has <code>@this(myTemplate: SomeTemplate)</code> the Twirl 2.6 template source file that
+    * implements <code>SomeTemplate</code> is <code>mytemplate.scala.html</code>.
+    *
+    * @param play26Templates a [[Set[File]]] as per
+    * [[sbt.FileFunction#cached(java.io.File, sbt.FilesInfo.Style, sbt.FilesInfo.Style, scala.Function1)]] requirements
+    * @return [[Set[File]]]
+    */
+  def generatePlay25Templates(play26Templates: Set[File]): Set[File] =
+    play26Templates.map { play26Source =>
+      val content = convertToPlay25Template(play26Source)
+      val file     = new File(play26Source.getPath.replace("play-26", "play-25"))
+
+      if (!file.getParentFile.exists()) {
+        file.getParentFile.mkdirs()
+      }
+
+      IO.write(file = file, content = content, append = false)
+
+      file
+    }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,28 @@
+import uk.gov.hmrc.playcrosscompilation.PlayVersion.Play26
+
+resolvers ++= Seq(
+  Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
+    Resolver.ivyStylePatterns),
+  "HMRC Releases" at "https://dl.bintray.com/hmrc/releases",
+  "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+)
+
+(managedSources in Compile) += (baseDirectory.value / "project" / "PlayCrossCompilation.scala")
+
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % PlayCrossCompilation.playRevision)
+
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.15.0")
+
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.17.0")
+
+val twirlPluginVersion =
+  if (PlayCrossCompilation.playVersion == Play26) "1.3.15" else "1.1.1"
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % twirlPluginVersion)
+
+addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.17.0")
+
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.19.0")
+
+
+

--- a/project/project/PlayCrossCompilation.scala
+++ b/project/project/PlayCrossCompilation.scala
@@ -1,0 +1,11 @@
+import uk.gov.hmrc.playcrosscompilation.AbstractPlayCrossCompilation
+import uk.gov.hmrc.playcrosscompilation.PlayVersion._
+
+object PlayCrossCompilation extends AbstractPlayCrossCompilation(defaultPlayVersion = Play26) {
+  val playRevision: String = PlayCrossCompilation.playVersion match {
+    case Play25 => "2.5.19"
+    case Play26 => "2.6.23"
+  }
+
+  val sbtPlayCrossCompilationVersion = "0.17.0"
+}

--- a/project/project/build.properties
+++ b/project/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.17

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,4 @@
+resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
+  Resolver.ivyStylePatterns)
+
+addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "0.17.0")

--- a/src/it/play-25/uk/gov/hmrc/hmrcfrontend/support/Implicits.scala
+++ b/src/it/play-25/uk/gov/hmrc/hmrcfrontend/support/Implicits.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.support
+
+import play.api.libs.ws.WSResponse
+
+object Implicits {
+
+  implicit class RichWSResponse(response: WSResponse) {
+    def bodyAsString: String = response.body
+  }
+}

--- a/src/it/play-26/uk/gov/hmrc/hmrcfrontend/support/Implicits.scala
+++ b/src/it/play-26/uk/gov/hmrc/hmrcfrontend/support/Implicits.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.support
+
+import play.api.libs.ws.WSResponse
+
+object Implicits {
+
+  implicit class RichWSResponse(response: WSResponse) {
+    def bodyAsString: String = response.body[String]
+  }
+}

--- a/src/it/scala/uk/gov/hmrc/hmrcfrontend/support/ScalaCheckUtils.scala
+++ b/src/it/scala/uk/gov/hmrc/hmrcfrontend/support/ScalaCheckUtils.scala
@@ -1,0 +1,27 @@
+package uk.gov.hmrc.hmrcfrontend.support
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop.collect
+
+object ScalaCheckUtils {
+
+  type ClassifyParams = (Boolean, Any, Any)
+
+  /**
+    * Collect statistics after checking a property. See [[Prop.classify]]
+    * Convenience method that avoids nesting several [[Prop.classify]] by providing a [[Stream]] of conditions.
+    * A [[Stream]] is used to avoid evaluating the conditions prematurely.
+    *
+    * @param conditions [[Stream]] of triples (condition, ifTrue, ifFalse)
+    * @param prop a scalacheck property [[Prop]]
+    * @return [[Prop]]
+    */
+  @scala.annotation.tailrec
+  def classify(conditions: Stream[ClassifyParams])(prop: Prop): Prop = conditions match {
+    case Stream.Empty => prop
+    case h #:: Stream.Empty =>
+      if (h._1) collect(h._2)(prop) else collect(h._3)(prop)
+    case h #:: t =>
+      classify(t)(Prop.classify(h._1, h._2, h._3)(prop))
+  }
+}

--- a/src/it/scala/uk/gov/hmrc/hmrcfrontend/support/TemplateIntegrationSpec.scala
+++ b/src/it/scala/uk/gov/hmrc/hmrcfrontend/support/TemplateIntegrationSpec.scala
@@ -1,0 +1,143 @@
+package uk.gov.hmrc.hmrcfrontend.support
+
+import org.jsoup.Jsoup
+import org.scalacheck.Prop.{forAll, secure}
+import org.scalacheck.{Arbitrary, Properties, ShrinkLowPriority, Test}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import play.api.libs.json.{Json, OWrites}
+import uk.gov.hmrc.hmrcfrontend.support.Implicits._
+import uk.gov.hmrc.hmrcfrontend.support.ScalaCheckUtils.{ClassifyParams, classify}
+import uk.gov.hmrc.hmrcfrontend.views.TemplateDiff._
+import uk.gov.hmrc.hmrcfrontend.views.{JsoupHelpers, PreProcessor, TemplateValidationException, TwirlRenderer}
+import scala.util.{Failure, Success}
+
+/**
+  * Base class for integration testing a Twirl template against the Nunjucks template rendering service
+  *
+  * @tparam T Type representing the input parameters of the Twirl template
+  */
+abstract class TemplateIntegrationSpec[T: OWrites: Arbitrary](hmrcComponentName: String, seed: Option[String] = None)
+    extends Properties(hmrcComponentName)
+    with TemplateServiceClient
+    with PreProcessor
+    with TwirlRenderer[T]
+    with ShrinkLowPriority
+    with JsoupHelpers
+    with ScalaFutures
+    with IntegrationPatience {
+
+  /**
+    * [[Stream]] of [[org.scalacheck.Prop.classify]] conditions to collect statistics on a property
+    * Used to check the distribution of generated data
+    *
+    * @param templateParams
+    * @return [[Stream[ClassifyParams]] of arguments to [[org.scalacheck.Prop.classify]]
+    */
+  def classifiers(templateParams: T): Stream[ClassifyParams] =
+    Stream.empty[ClassifyParams]
+
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+    p.withMinSuccessfulTests(50)
+
+  /* This is just an idea for a reporter that would look at the counts instead of rounded frequencies.
+
+  // Due to rounding in [[org.scalacheck.util.Pretty.prettyFreqMap]] the console reporter shows some
+  // frequencies collected from the classifiers as 0% when they are not zero.
+  // This reporter looks for counts instead of ratios in the classifiers which can signal problems in the generator
+  // and/or an insufficient number of test runs
+  override def overrideParameters(p: Test.Parameters): Test.Parameters =
+    p.withTestCallback(p.testCallback chain new TestCallback {
+        override def onTestResult(name: String, result: Test.Result): Unit = {
+          println(s"Generator reporter $name")
+          val threshold = 2
+          val lowStats = result.freqMap.getCounts.filter { case (_, c) => c < threshold }
+          if (lowStats.nonEmpty) {
+            pprint.pprintln(
+              "some stats are very low, tweak the generator to provide better coverage and/or increase the minSuccessfulTests parameter")
+            pprint.pprintln(emptyStats, width = 80, height = Int.MaxValue)
+          }
+        }
+
+      })
+   */
+
+  /**
+    * Property that renders the Twirl template and uses the template rendering service to render the equivalent
+    * Nunjucks template, and checks the outputs are equal. If provided, it uses the [[classifiers]] to collect statistics
+    * about the template parameters to analyse the distribution of the generators.
+    */
+  propertyWithSeed(s"$hmrcComponentName should render the same markup as the nunjucks renderer", seed) = forAll {
+    templateParams: T =>
+      classify(classifiers(templateParams))(secure {
+
+        val response = render(hmrcComponentName, templateParams)
+
+        val nunJucksOutputHtml = response.futureValue.bodyAsString
+
+        val tryRenderTwirl =
+          render(templateParams)
+            .transform(html => Success(html.body), f => Failure(new TemplateValidationException(f.getMessage)))
+
+        tryRenderTwirl match {
+
+          case Success(twirlOutputHtml) =>
+            val preProcessedTwirlHtml    = preProcess(twirlOutputHtml)
+            val preProcessedNunjucksHtml = preProcess(nunJucksOutputHtml)
+            val prop                     = preProcessedTwirlHtml == preProcessedNunjucksHtml
+
+            if (!prop) {
+              reportDiff(
+                preProcessedTwirlHtml    = preProcessedTwirlHtml,
+                preProcessedNunjucksHtml = preProcessedNunjucksHtml,
+                templateParams           = templateParams,
+                templateParamsJson       = Json.prettyPrint(Json.toJson(templateParams))
+              )
+            }
+
+            prop
+          case Failure(TemplateValidationException(message)) =>
+            println(s"Failed to validate the parameters for the $hmrcComponentName template")
+            println(s"Exception: $message")
+            println("Skipping property evaluation")
+
+            true
+        }
+      })
+  }
+
+  def reportDiff(
+    preProcessedTwirlHtml: String,
+    preProcessedNunjucksHtml: String,
+    templateParams: T,
+    templateParamsJson: String): Unit = {
+
+    val diffPath =
+      templateDiffPath(
+        twirlOutputHtml    = preProcessedTwirlHtml,
+        nunJucksOutputHtml = preProcessedNunjucksHtml,
+        diffFilePrefix     = Some(hmrcComponentName)
+      )
+
+    println(s"Diff between Twirl and Nunjucks outputs (please open diff HTML file in a browser): file://$diffPath\n")
+
+    println("-" * 80)
+    println("Twirl")
+    println("-" * 80)
+
+    val formattedTwirlHtml = Jsoup.parseBodyFragment(preProcessedTwirlHtml).body.html
+    println(s"\nTwirl output:\n$formattedTwirlHtml\n")
+
+    println(s"\nparameters: ")
+    pprint.pprintln(templateParams, width = 80, height = 500)
+
+    println("-" * 80)
+    println("Nunjucks")
+    println("-" * 80)
+
+    val formattedNunjucksHtml = Jsoup.parseBodyFragment(preProcessedNunjucksHtml).body.html
+    println(s"\nNunjucks output:\n$formattedNunjucksHtml\n")
+
+    println(s"\nparameters: ")
+    println(templateParamsJson)
+  }
+}

--- a/src/it/scala/uk/gov/hmrc/hmrcfrontend/support/TemplateServiceClient.scala
+++ b/src/it/scala/uk/gov/hmrc/hmrcfrontend/support/TemplateServiceClient.scala
@@ -1,0 +1,27 @@
+package uk.gov.hmrc.hmrcfrontend.support
+
+import org.scalatest.WordSpecLike
+import org.scalatestplus.play.PortNumber
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.libs.json.{Json, OWrites}
+import play.api.libs.ws.{WSClient, WSResponse}
+import uk.gov.hmrc.hmrcfrontend.views.HmrcFrontendDependency.hmrcFrontendVersion
+import scala.concurrent.Future
+
+trait TemplateServiceClient extends WordSpecLike with WSScalaTestClient with GuiceOneAppPerSuite {
+
+  implicit val portNumber: PortNumber = PortNumber(3000)
+
+  implicit lazy val wsClient: WSClient = app.injector.instanceOf[WSClient]
+
+  /**
+    * Render a hmrc-frontend component using the template service
+    *
+    * @param hmrcComponentName the hmrc-frontend component name as documented in the template service
+    * @param templateParams
+    * @return [[WSResponse]] with the rendered component
+    */
+  def render[T: OWrites](hmrcComponentName: String, templateParams: T, hmrcVersion: String = hmrcFrontendVersion): Future[WSResponse] =
+    wsUrl(s"hmrc/$hmrcVersion/components/$hmrcComponentName")
+      .post(Json.toJson(templateParams))
+}

--- a/src/it/scala/uk/gov/hmrc/hmrcfrontend/support/Utils.scala
+++ b/src/it/scala/uk/gov/hmrc/hmrcfrontend/support/Utils.scala
@@ -1,0 +1,10 @@
+package uk.gov.hmrc.hmrcfrontend.support
+
+object Utils {
+
+  implicit class RichString(url: String) {
+
+    def +/(otherUrl: String): String =
+      if (otherUrl.startsWith("/")) url + otherUrl else url + "/" + otherUrl
+  }
+}

--- a/src/it/scala/uk/gov/hmrc/hmrcfrontend/support/WSScalaTestClient.scala
+++ b/src/it/scala/uk/gov/hmrc/hmrcfrontend/support/WSScalaTestClient.scala
@@ -1,0 +1,11 @@
+package uk.gov.hmrc.hmrcfrontend.support
+
+import org.scalatestplus.play.PortNumber
+import play.api.libs.ws.{WSClient, WSRequest}
+import Utils._
+
+trait WSScalaTestClient {
+
+  def wsUrl(url: String)(implicit portNumber: PortNumber, wsClient: WSClient): WSRequest =
+    wsClient.url("http://localhost:" + portNumber.value +/ url)
+}

--- a/src/it/scala/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeadingIntegrationSpec.scala
+++ b/src/it/scala/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeadingIntegrationSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.components
+
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.hmrcfrontend.support.TemplateIntegrationSpec
+import uk.gov.hmrc.hmrcfrontend.views.html.components._
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.pageheading.PageHeading
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.pageheading.Generators._
+import scala.util.Try
+
+object hmrcPageHeadingIntegrationSpec
+    extends TemplateIntegrationSpec[PageHeading](hmrcComponentName = "hmrcPageHeading", seed = None) {
+
+  override def render(pageHeading: PageHeading): Try[HtmlFormat.Appendable] =
+    Try(HmrcPageHeading(pageHeading))
+}

--- a/src/main/play-25/resources/hmrcfrontend.routes
+++ b/src/main/play-25/resources/hmrcfrontend.routes
@@ -1,0 +1,1 @@
+GET        /assets/*file        @uk.gov.hmrc.hmrcfrontend.controllers.Assets.at(path="/public/lib/hmrc-frontend/hmrc", file)

--- a/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeading.scala.html
+++ b/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeading.scala.html
@@ -1,0 +1,13 @@
+
+
+
+
+@(params: PageHeading)
+@import params._
+<header class="hmrc-page-heading">
+    <h1 class="govuk-heading-xl">@text</h1>
+    @section match {
+      case Some(NonEmptyString(s)) => {<p class="govuk-caption-xl hmrc-caption-xl"><span class="govuk-visually-hidden">This section is </span>@s</p>}
+      case Some(_) | None => {}
+    }
+</header>

--- a/src/main/play-25/uk/gov/hmrc/hmrcfrontend/controllers/Assets.scala
+++ b/src/main/play-25/uk/gov/hmrc/hmrcfrontend/controllers/Assets.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.controllers
+
+import controllers.AssetsBuilder
+import javax.inject.{Inject, Singleton}
+import play.api.http.HttpErrorHandler
+
+/*
+  * Without this we get
+  * [RuntimeException: java.lang.NoSuchMethodError: controllers.ReverseAssets.versioned(Ljava/lang/String;)Lplay/api/mvc/Call;]
+  * when using Assets.
+ */
+@Singleton
+class Assets @Inject()(errorHandler: HttpErrorHandler) extends AssetsBuilder(errorHandler)

--- a/src/main/play-25/uk/gov/hmrc/hmrcfrontend/views/html/components/package.scala
+++ b/src/main/play-25/uk/gov/hmrc/hmrcfrontend/views/html/components/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+package html
+
+package object components extends Utils with Aliases {
+
+  /**
+   * Top-level implicits for all components
+   */
+  object implicits extends Implicits
+
+  lazy val HmrcPageHeading = hmrcPageHeading
+
+}

--- a/src/main/play-26/resources/hmrcfrontend.routes
+++ b/src/main/play-26/resources/hmrcfrontend.routes
@@ -1,0 +1,1 @@
+GET        /assets/*file        uk.gov.hmrc.hmrcfrontend.controllers.Assets.at(path="/public/lib/hmrc-frontend/hmrc", file)

--- a/src/main/play-26/resources/reference.conf
+++ b/src/main/play-26/resources/reference.conf
@@ -1,0 +1,18 @@
+# Copyright 2019 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+play.assets {
+  path = "/public"
+  urlPrefix = "/assets"
+}

--- a/src/main/play-26/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeading.scala.html
+++ b/src/main/play-26/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeading.scala.html
@@ -1,0 +1,27 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(params: PageHeading)
+@import params._
+<header class="hmrc-page-heading">
+    <h1 class="govuk-heading-xl">@text</h1>
+    @section match {
+      case Some(NonEmptyString(s)) => {<p class="govuk-caption-xl hmrc-caption-xl"><span class="govuk-visually-hidden">This section is </span>@s</p>}
+      case Some(_) | None => {}
+    }
+</header>

--- a/src/main/play-26/uk/gov/hmrc/hmrcfrontend/controllers/Assets.scala
+++ b/src/main/play-26/uk/gov/hmrc/hmrcfrontend/controllers/Assets.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.controllers
+
+import controllers.{AssetsBuilder, AssetsMetadata}
+import javax.inject.{Inject, Singleton}
+import play.api.http.HttpErrorHandler
+
+/*
+  * Without this we get
+  * [RuntimeException: java.lang.NoSuchMethodError: controllers.ReverseAssets.versioned(Ljava/lang/String;)Lplay/api/mvc/Call;]
+  * when using Assets.
+ */
+@Singleton
+class Assets @Inject()(errorHandler: HttpErrorHandler, meta: AssetsMetadata) extends AssetsBuilder(errorHandler, meta)

--- a/src/main/play-26/uk/gov/hmrc/hmrcfrontend/views/html/components/package.scala
+++ b/src/main/play-26/uk/gov/hmrc/hmrcfrontend/views/html/components/package.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+package html
+
+package object components extends  Utils with Aliases {
+
+  /**
+   * Top-level implicits for all components
+   */
+  object implicits extends Implicits
+
+  type HmrcPageHeading = hmrcPageHeading
+  @deprecated(message="Use DI", since="Play 2.6")
+  lazy val HmrcPageHeading = new hmrcPageHeading()
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Aliases.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Aliases.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+trait Aliases {
+  type PageHeading = viewmodels.pageheading.PageHeading
+  val PageHeading = viewmodels.pageheading.PageHeading
+}
+
+object Aliases extends Aliases

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Implicits.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Implicits.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import play.twirl.api.{Html, HtmlFormat}
+
+trait Implicits {
+
+  implicit class RichHtml(html: Html) {
+
+    def padLeft(padCount: Int = 1, padding: String = " "): Html = {
+      val padStr = " " * (if (html.body.isEmpty) 0 else padCount)
+      HtmlFormat.fill(collection.immutable.Seq(Html(padStr), html))
+    }
+
+    def trim: Html =
+      Html(html.toString.trim)
+
+    def ltrim: Html =
+      Html(html.toString.ltrim)
+
+    def rtrim: Html =
+      Html(html.toString.rtrim)
+
+    /**
+     * Based on the behaviour of [[https://mozilla.github.io/nunjucks/templating.html#indent]]
+     * @param n
+     * @param indentFirstLine
+     */
+    def indent(n: Int, indentFirstLine: Boolean = false): Html =
+      Html(html.toString.indent(n, indentFirstLine))
+
+    def nonEmpty: Boolean =
+      html.body.nonEmpty
+  }
+
+  implicit class RichString(s: String) {
+
+    def toOption: Option[String] =
+      if (s == null || s.isEmpty) None else Some(s)
+
+    def ltrim = s.replaceAll("^\\s+", "")
+
+    def rtrim = s.replaceAll("\\s+$", "")
+
+    /**
+     * Indent a (multiline) string <code>n</code> spaces.
+     * @param n Number of spaces to indent the string. It can be a negative value, in which case it attempts to unindent
+     *          n spaces, as much as possible until it hits the margin.
+     * @param indentFirstLine
+     * @return
+     */
+    def indent(n: Int, indentFirstLine: Boolean = false): String = {
+      @scala.annotation.tailrec
+      def recurse(m: Int, lines: Seq[String]): Seq[String] = m match {
+        case 0 => lines
+        case m => recurse(math.abs(m) - 1, indent1(math.signum(n), lines))
+      }
+
+      val lines         = s.split("\n", -1).toSeq // limit=-1 so if a line ends with \n include the trailing blank line
+      val linesToIndent = if (indentFirstLine) lines else if (lines.length > 1) lines.tail else Nil
+      val indentedLines = recurse(n, linesToIndent)
+
+      (if (indentFirstLine) indentedLines else (lines.head +: indentedLines)).mkString("\n")
+    }
+
+    private def indent1(signal: Int, lines: Seq[String]) = {
+      def canUnindent: Boolean =
+        lines.forall(_.startsWith(" "))
+
+      if (signal < 0 && canUnindent) {
+        lines.map(_.drop(1))
+      } else if (signal < 0) {
+        lines
+      } else {
+        lines.map(" " + _)
+      }
+    }
+
+    /**
+     * Implements [[https://mozilla.github.io/nunjucks/templating.html#capitalize]].
+     * Unlike Scala's [[scala.collection.immutable.StringLike#capitalize()]] Nunjucks' capitalize converts the first
+     * letter to uppercase and the rest to lowercase.
+     *
+     * @return
+     */
+    def nunjucksCapitalize: String =
+      s.toLowerCase.capitalize
+
+  }
+
+  /**
+   * Mapping, folding and getOrElse on Option[String] for non-empty strings.
+   * Commonly used in the Twirl components.
+   *
+   * @param optString
+   */
+  implicit class RichOptionString(optString: Option[String]) {
+    def mapNonEmpty[T](f: String => T): Option[T] =
+      optString.filter(_.nonEmpty).map(f)
+
+    def foldNonEmpty[B](ifEmpty: => B)(f: String => B): B =
+      optString.filter(_.nonEmpty).fold(ifEmpty)(f)
+
+    def getNonEmptyOrElse[B >: String](default: => B): B =
+      optString.filter(_.nonEmpty).getOrElse(default)
+  }
+
+}
+
+object Implicits extends Implicits

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/IntString.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/IntString.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import play.api.libs.json.{Format, JsError, JsNumber, JsResult, JsString, JsSuccess, JsValue, Reads}
+
+import scala.util.Try
+
+
+case class IntString(int: Int) extends AnyVal {
+  def str: String = int.toString
+}
+
+object IntString {
+
+  def apply(intStr: String): Try[IntString] = Try(intStr.toInt).map(IntString(_))
+
+  implicit object IntStringFormat extends Format[IntString] {
+    def reads(json: JsValue): JsResult[IntString] = json match {
+      case JsNumber(n) if n.isValidInt => JsSuccess(IntString(n.toInt))
+      case JsNumber(_) => JsError("error.expected.validinteger")
+      case JsString(s) => IntString(s).map(JsSuccess(_)).getOrElse(JsError("error.expected.integerstring"))
+      case _ => JsError("error.expected.integerjsstringorjsnumber")
+    }
+
+    def writes(o: IntString): JsString = JsString(o.str)
+  }
+
+  implicit class IntStringReads(intStringReads: Reads[IntString]) {
+    def int: Reads[Int] = intStringReads.map(_.int)
+    def str: Reads[String] = intStringReads.map(_.str)
+  }
+
+  implicit class IntStringNullableReads(intStringNullableReads: Reads[Option[IntString]]) {
+    def int: Reads[Option[Int]] = intStringNullableReads.map(_.map(_.int))
+    def str: Reads[Option[String]] = intStringNullableReads.map(_.map(_.str))
+  }
+
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Utils.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Utils.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import play.api.templates.PlayMagic.toHtmlArgs
+import play.twirl.api.Html
+import html.components.implicits._
+
+trait Utils {
+
+  /**
+   * Creates a space-separated list of CSS classes to be included in a template.
+   *
+   * @param firstClass
+   * @param rest
+   * @return
+   */
+  def toClasses(firstClass: String, rest: String*): String =
+    rest.foldLeft(firstClass)((acc, curr) => if (curr.isEmpty) acc else s"$acc $curr")
+
+  /**
+   * Creates an HTML fragment with pairs of attribute=value.
+   * The attributes HTML fragment is padded on the left with 1 space by default so when it is used in a template
+   * it is nicely separated from the previous element.
+   *
+   * @param attributes
+   * @param padCount
+   * @return [[Html]]
+   */
+  def toAttributes(attributes: Map[String, String], padCount: Int = 1): Html = {
+    val htmlArgs = toHtmlArgs(attributes.map { case (k, v) => Symbol(k) -> v })
+    htmlArgs.padLeft(if (attributes.nonEmpty) padCount else 0)
+  }
+
+  object NonEmptyString {
+    def unapply(s: String): Option[String] =
+      if (s != null && s.nonEmpty) Some(s) else None
+  }
+}
+
+object Utils extends Utils

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/JsonDefaultValueFormatter.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/JsonDefaultValueFormatter.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels
+
+import play.api.libs.json._
+
+// FIXME: Remove when moving to Play >= 2.6
+/***
+  * Play 2.5 doesn't have `Json.using[Json.WithDefaultValues]` or `Json.readWithDefault` to deserialise Json with missing paths.
+  * This feature was introduced in Play 2.6 so this is a workaround taken from: from [[https://medium.com/@gauravsingharoy/how-to-add-defaults-for-missing-properties-in-scala-play-json-unmarshalling-70ff10b775e3]]
+  *
+  * @tparam T
+  */
+trait JsonDefaultValueFormatter[T] {
+
+  def defaultObject: T
+
+  def defaultReads: Reads[T]
+
+  implicit def jsonWrites: OWrites[T]
+
+  // The idea here is to create an instance of the case class with default values and merge its Json representation.
+  // with the deserialised Json.
+  // The case class must have default values for all fields.
+  implicit def jsonReads: Reads[T] = new Reads[T] {
+    def reads(json: JsValue): JsResult[T] = {
+      val defaultJson = Json.toJson(defaultObject)
+      val finalJson   = Seq(defaultJson, json).foldLeft(Json.obj())((obj, a) => obj.deepMerge(a.as[JsObject]))
+      defaultReads.reads(finalJson)
+    }
+  }
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/JsonImplicits.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/JsonImplicits.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels
+
+import play.api.libs.json.{JsPath, JsString, JsValue, Json, Reads}
+
+trait JsonImplicits {
+  // FIXME: To remove. Coming soon in Play 2.7.x https://www.playframework.com/documentation/2.7.x/api/scala/play/api/libs/json/Format.html#widen[B%3E:A]:play.api.libs.json.Reads[B]
+  implicit class RichReads[A](r: Reads[A]) {
+    def widen[B >: A]: Reads[B] = Reads[B] { r.reads }
+  }
+
+  /**
+   * Parse fields with unknown type to [[String]]
+   *
+   * @param jsPath
+   */
+  implicit class RichJsPath(jsPath: JsPath) {
+    def readsJsValueToString: Reads[String] =
+      jsPath
+        .read[JsValue]
+        .map {
+          case JsString(s) => s
+          case x           => Json.stringify(x)
+        }
+  }
+}
+
+object JsonImplicits extends JsonImplicits

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/content/Content.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/content/Content.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels
+package content
+
+import play.api.libs.json._
+import play.twirl.api.{Html, HtmlFormat}
+import JsonImplicits._
+
+sealed trait Content {
+  def asHtml: Html
+
+  def nonEmpty: Boolean = this match {
+    case NonEmptyHtml(_) | NonEmptyText(_) => true
+    case _                                 => false
+  }
+}
+
+object Content {
+
+  implicit val reads: Reads[Content] =
+    readsHtmlOrText((__ \ "html"), (__ \ "text"))
+
+  def writesContent(htmlField: String = "html", textField: String = "text"): OWrites[Content] =
+    new OWrites[Content] {
+      override def writes(content: Content): JsObject = content match {
+        case Empty              => Json.obj()
+        case HtmlContent(value) => Json.obj(htmlField -> value.body)
+        case Text(value)        => Json.obj(textField -> value)
+      }
+    }
+
+  implicit val writes: OWrites[Content] = writesContent()
+
+  def readsHtmlOrText(htmlJsPath: JsPath, textJsPath: JsPath): Reads[Content] =
+    readsHtmlContent(htmlJsPath)
+      .widen[Content]
+      .orElse(readsText(textJsPath).widen[Content])
+      .orElse(Reads.pure[Content](Empty))
+
+  def readsHtmlContent(jsPath: JsPath = (__ \ "html")): Reads[HtmlContent] =
+    jsPath.readsJsValueToString.map(HtmlContent(_))
+
+  def readsText(jsPath: JsPath = (__ \ "text")): Reads[Text] =
+    jsPath.readsJsValueToString.map(Text)
+}
+
+case object Empty extends Content {
+  override def asHtml: Html = HtmlFormat.empty
+}
+
+final case class HtmlContent(value: Html) extends Content {
+  override def asHtml: Html = value
+}
+
+object HtmlContent {
+  def apply(string: String): HtmlContent =
+    HtmlContent(Html(string))
+}
+
+object NonEmptyHtml {
+  def unapply(htmlContent: HtmlContent): Option[Html] =
+    if (htmlContent.value.body.isEmpty) None else Some(htmlContent.value)
+}
+
+final case class Text(value: String) extends Content {
+  override def asHtml: Html = HtmlFormat.escape(value)
+}
+
+object NonEmptyText {
+  def unapply(text: Text): Option[String] =
+    if (text.value == null || text.value.isEmpty) None else Some(text.value)
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/pageheading/PageHeading.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/pageheading/PageHeading.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.pageheading
+
+import play.api.libs.json._
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.JsonDefaultValueFormatter
+
+case class PageHeading(
+  text: String            = "",
+  section: Option[String] = None
+)
+
+object PageHeading extends JsonDefaultValueFormatter[PageHeading] {
+
+  override def defaultObject: PageHeading = PageHeading()
+
+  override def defaultReads: Reads[PageHeading] = Json.reads[PageHeading]
+
+  override implicit def jsonWrites: OWrites[PageHeading] = Json.writes[PageHeading]
+}

--- a/src/test/play-25/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeadingSpec.scala
+++ b/src/test/play-25/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeadingSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+package components
+
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.hmrcfrontend.views.html.components._
+import scala.util.Try
+
+class hmrcPageHeadingSpec extends TemplateUnitSpec[PageHeading]("hmrcPageHeading") {
+
+  /**
+   * Calls the Twirl template with the given parameters and returns the resulting markup
+   *
+   * @param templateParams
+   * @return [[Try[HtmlFormat.Appendable]]] containing the markup
+   */
+  override def render(templateParams: PageHeading): Try[HtmlFormat.Appendable] =
+    Try(HmrcPageHeading(templateParams))
+}

--- a/src/test/play-26/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeadingSpec.scala
+++ b/src/test/play-26/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeadingSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+package components
+
+import javax.inject.Inject
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.hmrcfrontend.views.html.components._
+import scala.util.Try
+
+class hmrcPageHeadingSpec @Inject()(hmrcPageHeading: HmrcPageHeading) extends TemplateUnitSpec[PageHeading]("hmrcPageHeading") {
+
+  /**
+   * Calls the Twirl template with the given parameters and returns the resulting markup
+   *
+   * @param templateParams
+   * @return [[Try[HtmlFormat.Appendable]]] containing the markup
+   */
+  override def render(templateParams: PageHeading): Try[HtmlFormat.Appendable] =
+    Try(hmrcPageHeading(templateParams))
+}

--- a/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-default/component.json
+++ b/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-default/component.json
@@ -1,0 +1,3 @@
+{
+  "name": "hmrcPageHeading"
+}

--- a/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-default/input.json
+++ b/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-default/input.json
@@ -1,0 +1,3 @@
+{
+  "text": "What is your name?"
+}

--- a/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-default/output.html
+++ b/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-default/output.html
@@ -1,0 +1,3 @@
+<header class="hmrc-page-heading">
+    <h1 class="govuk-heading-xl">What is your name?</h1>
+</header>

--- a/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-with-section/component.json
+++ b/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-with-section/component.json
@@ -1,0 +1,3 @@
+{
+  "name": "hmrcPageHeading"
+}

--- a/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-with-section/input.json
+++ b/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-with-section/input.json
@@ -1,0 +1,4 @@
+{
+  "text": "What is your name?",
+  "section": "Personal details"
+}

--- a/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-with-section/output.html
+++ b/src/test/resources/fixtures/test-fixtures-1.5.0/page-heading-with-section/output.html
@@ -1,0 +1,4 @@
+<header class="hmrc-page-heading">
+    <h1 class="govuk-heading-xl">What is your name?</h1>
+    <p class="govuk-caption-xl hmrc-caption-xl"><span class="govuk-visually-hidden">This section is </span>Personal details</p>
+</header>

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/controllers/AssetsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/controllers/AssetsSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.controllers
+
+import org.scalatest.TestData
+import org.scalatestplus.play._
+import org.scalatestplus.play.guice.GuiceOneAppPerTest
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc._
+import play.api.test.Helpers._
+import play.api.test._
+
+class AssetsSpec extends PlaySpec with Results with GuiceOneAppPerTest {
+
+  override def newAppForTest(testData: TestData): Application =
+    new GuiceApplicationBuilder()
+      .configure(testData.configMap ++ Map("play.http.router" -> "hmrcfrontend.Routes"))
+      .build()
+
+  "Asset controller " must {
+    "serve an asset in the public assets folder" in {
+      status(route(app, FakeRequest("GET", "/assets/all.js")).get) must be(200)
+    }
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/CrossCompiledTemplatesSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/CrossCompiledTemplatesSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import better.files._
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.BuildInfo
+
+class CrossCompiledTemplatesSpec extends WordSpec with Matchers {
+
+  val playDir: String = BuildInfo.playVersion match {
+    case "Play25" => "play-25"
+    case "Play26" => "play-26"
+    case _        => throw new IllegalArgumentException("Expecting Play25 or Play26")
+  }
+
+  val otherPlayDir: String = playDir match {
+    case "play-25" => "play-26"
+    case "play-26" => "play-25"
+    case _         => throw new IllegalArgumentException("Expecting play-25 or play-26")
+  }
+
+  BuildInfo.twirlCompileTemplates_sources.foreach { templateFile =>
+    val otherTemplateFile =
+      File(templateFile.getAbsolutePath.replaceFirst(playDir, otherPlayDir))
+
+    s"Cross-compiled template $templateFile" should {
+      s"be in sync with template $otherTemplateFile" in {
+        if (otherTemplateFile.exists) {
+          loadTemplate(File(templateFile.getAbsolutePath)) shouldBe loadTemplate(otherTemplateFile)
+        } else {
+          fail(s"Template $otherTemplateFile not implemented yet")
+        }
+      }
+    }
+  }
+
+  "stripThisDeclaration" should {
+    "strip the @this declaration from a template" in {
+      val templateContents =
+        """
+          |@import somepackage
+          |
+          |@this(aTemplate: ATemplate,
+          |      anotherTemplate: AnotherTemplate)
+          |
+          |@()
+          |<p>A nice paragraph</p>
+          |""".stripMargin
+
+      stripDIDeclaration(templateContents) shouldBe
+        """
+          |@import somepackage
+          |
+          |
+          |
+          |@()
+          |<p>A nice paragraph</p>
+          |""".stripMargin
+
+    }
+  }
+
+  def loadTemplate(templateFile: File): String = {
+    val contents          = templateFile.contentAsString
+    val templateBeginning = """@\(""".r
+    val matchBeginning    = templateBeginning.findFirstMatchIn(contents)
+    val start             = matchBeginning.map(_.start).getOrElse(0)
+    contents.substring(start)
+  }
+
+  def stripDIDeclaration(contents: String): String = {
+    val thisDeclarationRegex = """(?s)@this\(.*?\)""".r
+    val optMatch    = thisDeclarationRegex.findFirstMatchIn(contents)
+    optMatch.map { m =>
+      val thisDeclaration = m.group(0)
+      contents.replace(thisDeclaration, "")
+    }.getOrElse(contents)
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/DiffWrapper.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/DiffWrapper.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import java.nio.file.Path
+import java.util
+import java.util.UUID
+
+import better.files._
+import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+case class DiffWrapper(differ: DiffMatchPatch) {
+
+  /**
+    * Compute the diff between two strings
+    *
+    * @param s first [[String]]
+    * @param t second [[String]]
+    * @return [[util.LinkedList[DiffMatchPatch.Diff]]]
+    */
+  def diff(s: String, t: String): util.LinkedList[DiffMatchPatch.Diff] = {
+    val diffResult = differ.diffMain(s, t)
+    val _          = differ.diffCleanupSemantic(diffResult)
+    diffResult
+  }
+
+  /**
+    * Write the diff in pretty HTML so it can be output at the end of a test failure
+    *
+    * @param diff
+    * @return [[Path]] to the file
+    */
+  def diffToHtml(diff: mutable.Buffer[DiffMatchPatch.Diff], diffFilePrefix: Option[String] = None): Path = {
+    // write diff as pretty html to a file
+    val diffHtml = differ.diffPrettyHtml(diff.asJava)
+
+    val userDir = System.getProperty("user.dir")
+    val prefix  = diffFilePrefix.map(_ + "-").getOrElse("")
+    val name    = s"${prefix}diff-${UUID.randomUUID.toString}.html"
+    val file    = userDir / "target" / name
+
+    file.overwrite(diffHtml)
+
+    file.path
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/DiffWrapperSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/DiffWrapperSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import better.files._
+import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.JavaConverters._
+
+class DiffWrapperSpec extends WordSpec with Matchers {
+
+  "diff" should {
+    "compute the diff between two strings" in new Setup {
+
+      val differ = diffWrapper.differ
+
+      val patch = differ.patchMake(diff)
+
+      val patchText = differ.patchToText(patch)
+
+      patchText shouldBe """@@ -1,9 +1,13 @@
+                           |-Hello
+                           |+Wonderful
+                           |  Wor
+                           |""".stripMargin
+    }
+
+    "diffToHtml" should {
+      "write the diff Html to a file" in new Setup {
+
+        val path = diffWrapper.diffToHtml(diff.asScala)
+
+        val file = File(path)
+
+        assert(file.exists)
+
+        file.contentAsString shouldBe """<del style="background:#ffe6e6;">Hello</del><ins style="background:#e6ffe6;">Wonderful</ins><span> World!</span>""".stripMargin
+      }
+    }
+  }
+}
+
+trait Setup {
+
+  val diffWrapper = new DiffWrapper(new DiffMatchPatch())
+
+  val s = "Hello World!"
+  val t = "Wonderful World!"
+
+  val diff = diffWrapper.diff(s, t)
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/HmrcFrontendDependency.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/HmrcFrontendDependency.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import uk.gov.hmrc.BuildInfo
+
+import scala.util.matching.Regex
+
+object HmrcFrontendDependency {
+  val hmrcFrontendVersionRegex: Regex = """org\.webjars\.npm:hmrc-frontend:(\d+\.\d+\.\d+)""".r
+
+  val hmrcFrontendVersion: String =
+    findFirstMatch(hmrcFrontendVersionRegex, BuildInfo.libraryDependencies)
+      .getOrElse(throw new RuntimeException("Unable to find the hmrc-frontend dependency"))
+      .group(1)
+
+  def findFirstMatch(regex: Regex, xs: Seq[String]): Option[Regex.Match] =
+    for {
+      x <- xs.find {
+            case regex(_*) => true
+            case _         => false
+          }
+      firstMatch <- regex.findFirstMatchIn(x)
+    } yield firstMatch
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/HmrcFrontendDependencySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/HmrcFrontendDependencySpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+import uk.gov.hmrc.hmrcfrontend.views.HmrcFrontendDependency._
+
+class HmrcFrontendDependencySpec extends WordSpec with Matchers with OptionValues {
+
+  "findFirstMatch" should {
+    "find the first match of a regular expression in a Seq" in {
+      val dependencies = Seq(
+        "org.scala-lang:scala-library:2.11.12",
+        "com.typesafe.play:twirl-api:1.3.15",
+        "com.typesafe.play:play-server:2.6.23",
+        "com.typesafe.play:play-test:2.6.23:test",
+        "com.typesafe.play:play-omnidoc:2.6.23:docs",
+        "com.typesafe.play:filters-helpers:2.6.23",
+        "com.typesafe.play:play-logback:2.6.23",
+        "com.typesafe.play:play-akka-http-server:2.6.23",
+        "com.typesafe.play:play:2.6.23",
+        "com.typesafe.play:filters-helpers:2.6.23",
+        "org.joda:joda-convert:2.0.2",
+        "org.webjars.npm:hmrc-frontend:1.5.0",
+        "org.scalatest:scalatest:3.0.5:test",
+        "org.pegdown:pegdown:1.6.0:test",
+        "org.jsoup:jsoup:1.11.3:test",
+        "com.typesafe.play:play-test:2.6.23:test",
+        "org.scalacheck:scalacheck:1.14.0:test",
+        "com.googlecode.htmlcompressor:htmlcompressor:1.5.2:test",
+        "com.github.pathikrit:better-files:3.8.0:test",
+        "org.scalatestplus.play:scalatestplus-play:3.1.2"
+      )
+
+      findFirstMatch(hmrcFrontendVersionRegex, dependencies).value.group(1) shouldBe "1.5.0"
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/ImplicitsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/ImplicitsSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import org.scalacheck.Arbitrary._
+import org.scalacheck.{Gen, ShrinkLowPriority}
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.twirl.api.{Html, HtmlFormat}
+import uk.gov.hmrc.hmrcfrontend.views.html.components.implicits._
+
+class ImplicitsSpec
+    extends WordSpec
+    with Matchers
+    with OptionValues
+    with ScalaCheckPropertyChecks
+    with ShrinkLowPriority {
+
+  import Generators._
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 50)
+
+  "padLeft" should {
+    "add left padding to non-empty HTML" in {
+
+      forAll(htmlGen, Gen.chooseNum(0, 5)) { (html, padCount) =>
+        (html, padCount) match {
+          case (HtmlExtractor(""), n)      => html.padLeft(n)              shouldBe HtmlFormat.empty
+          case (HtmlExtractor(content), 0) => html.padLeft(0).body         shouldBe content
+          case (HtmlExtractor(content), n) => html.padLeft(n).body.drop(1) shouldBe html.padLeft(n - 1).body
+        }
+      }
+
+      lazy val htmlGen: Gen[Html] = Gen.alphaStr.map(Html(_))
+
+      object HtmlExtractor {
+        def unapply(html: Html): Option[String] =
+          Some(html.body)
+      }
+
+    }
+  }
+
+  // prove the property:
+  // indent(n) = indent(n-1).indent(1) if n >=0
+  // indent(n) = indent(n+1).indent(-1) if n < 0
+  "indent(n, _)" should {
+    "be the same as indent(signum(n) * (abs(n)-1), _).indent(signum(n) * 1, _)" in {
+      forAll(genIndentArgs) {
+        case (s, n, indentFirstLine) =>
+          s.indent(n, indentFirstLine) shouldBe s
+            .indent(math.signum(n) * (math.abs(n) - 1), indentFirstLine)
+            .indent(math.signum(n) * 1, indentFirstLine)
+      }
+    }
+  }
+
+  object Generators {
+
+    /**
+      * Generate indentation arguments for [[uk.gov.hmrc.hmrcfrontend.views.Implicits.RichString.indent(int, boolean)]]
+      */
+    val genIndentArgs: Gen[(String, Int, Boolean)] =
+      for {
+        // generate text to indent with a maximum of 8 lines
+        nLines <- Gen.choose(0, 8)
+        maxInitialIndentation = 10
+        // Initial indentation for each line in the generated string: generate small indentations less often so we can test unindent more often
+        initialIndentations <- Gen.listOfN(nLines, Gen.frequency((10, Gen.oneOf(0 to 3)), (90, Gen.oneOf(4 to 10))))
+        // indentation for each line
+        paddings = initialIndentations.map(" " * _)
+        // maxIndentation > initialIndentation so we cover cases where we try to unindent (negative n) beyond the left margin
+        maxIndentation = maxInitialIndentation + 1
+        n <- Gen.chooseNum(-maxIndentation, maxIndentation)
+        // Generate lines interspersed with blank space lines
+        lineGen  = Gen.frequency((70, Gen.alphaStr), (30, Gen.const(" ")))
+        padLines = (lines: Seq[String]) => paddings.zip(lines).map { case (padding, s) => padding + s }
+        str <- Gen.frequency(
+                (
+                  90,
+                  Gen
+                    .listOfN(nLines, lineGen)
+                    .map(padLines)
+                    .map(_.mkString("\n"))),
+                (10, Gen.const(""))
+              )
+        indentFirstLine <- arbBool.arbitrary
+      } yield (str, n, indentFirstLine)
+
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/IntStringSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/IntStringSpec.scala
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import org.scalatest.{Matchers, WordSpec}
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json._
+
+import scala.util.Try
+
+
+class IntStringSpec extends WordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+
+  "fields for IntString" should {
+    "return int for int field" in {
+      forAll { int: Int =>
+        val intString = IntString(int)
+        intString.int shouldBe int
+      }
+    }
+
+    "return string form of int for str field" in {
+      forAll { int: Int =>
+        val intString = IntString(int)
+        intString.str shouldBe int.toString
+      }
+    }
+  }
+
+  "apply" should {
+    "apply directly on int parameter" in {
+      forAll { int: Int =>
+        IntString.apply(int)
+      }
+    }
+
+    "apply with success on int-like string" in {
+      forAll { int: Int =>
+        val validIntString: String = int.toString
+        IntString(validIntString).isSuccess
+      }
+    }
+
+    "apply with failure on non int-like string" in {
+      forAll {invalidIntString: String =>
+        whenever (Try(invalidIntString.toInt).isFailure) {
+          val attempt = IntString(invalidIntString)
+          assert(attempt.isFailure)
+          assert(attempt.failed.get.isInstanceOf[NumberFormatException])
+        }
+      }
+    }
+  }
+
+  "implicit reads" should {
+
+    "parse JsNumber with integer numbers as IntString" in {
+      forAll { int: Int =>
+        val jsNumber = JsNumber(int)
+        val intString = jsNumber.as[IntString]
+        intString.int shouldBe int
+      }
+    }
+
+    "fail to parse JsNumber with non-integer numbers as IntString" in {
+      forAll { bigDecimal: BigDecimal =>
+        whenever (!bigDecimal.isValidInt) {
+          val jsNumber = JsNumber(bigDecimal)
+          val attempt = Try(jsNumber.as[IntString])
+          assert(attempt.isFailure)
+          attempt.failed.map(_.getMessage).get should include("error.expected.validinteger")
+        }
+      }
+    }
+
+    "parse integer-like JsString as IntString" in {
+      forAll { int: Int =>
+        val validIntString: String = int.toString
+        val jsString = JsString(validIntString)
+        val intString = jsString.as[IntString]
+        intString.int shouldBe int
+        intString.str shouldBe validIntString
+      }
+    }
+
+    "fail to parse JsString with non integer-like numbers as IntString" in {
+      forAll { invalidIntString: String =>
+        whenever (Try(invalidIntString.toInt).isFailure) {
+          val jsString = JsString(invalidIntString)
+          val attempt = Try(jsString.as[IntString])
+          assert(attempt.isFailure)
+          attempt.failed.map(_.getMessage).get should include("error.expected.integerstring")
+        }
+      }
+    }
+
+    "fail to parse JsValues that are neither JsNumbers nor JsStrings to IntString" in {
+      val invalidJsValues: Iterable[JsValue] = Iterable(JsArray(), JsBoolean(false), JsBoolean(true), JsNull, Json.obj("foo" -> "bar"))
+
+      invalidJsValues.foreach { jsValue =>
+        val attempt = Try(jsValue.as[IntString])
+        assert(attempt.isFailure, s"- JsValue [${jsValue.getClass}: $jsValue] was unexpectedly able to be parsed as IntString instead of failing.")
+        withClue(s"- JsValue [${jsValue.getClass}: $jsValue] had incorrect error"){
+          attempt.failed.map(_.getMessage).get should include("error.expected.integerjsstringorjsnumber")
+        }
+      }
+    }
+  }
+
+  "explicit reads" should {
+
+    "give means to map JsValues that can successfully be parsed as IntString to Int" in {
+      val reads: Reads[IntString] = implicitly[Reads[IntString]]
+      val intermediateReads: Reads[Int] = reads.int
+      forAll { int: Int =>
+
+        val jsInt = JsNumber(int)
+        val parsedInt = jsInt.as[Int](intermediateReads)
+        int shouldBe parsedInt
+
+        val validIntString: String = int.toString
+        val jsString = JsString(validIntString)
+        val intParsedFromString = jsString.as[Int](intermediateReads)
+        int shouldBe intParsedFromString
+      }
+    }
+
+    "give means to map JsValues that can successfully be parsed as IntString to String" in {
+      val reads: Reads[IntString] = implicitly[Reads[IntString]]
+      val intermediateReads: Reads[String] = reads.str
+      forAll { int: Int =>
+
+        val jsInt = JsNumber(int)
+        val strParsedFromInt = jsInt.as[String](intermediateReads)
+        int.toString shouldBe strParsedFromInt
+
+        val validIntString: String = int.toString
+        val jsString = JsString(validIntString)
+        val strParsedFromIntString = jsString.as[String](intermediateReads)
+        validIntString shouldBe strParsedFromIntString
+      }
+    }
+
+    "give means to map JsValues that can successfully be parsed as Some[IntString] to Some[Int]" in {
+      forAll { int: Int =>
+        val expectedIntOption = Some(int)
+
+        val optReadsStub = new Reads[Option[IntString]] {
+          def reads(jsValue: JsValue): JsResult[Option[IntString]] = JsSuccess(Some(IntString(expectedIntOption.get)))
+        }
+
+        val intermediateReads: Reads[Option[Int]] = optReadsStub.int
+        JsString("foo").as[Option[Int]](intermediateReads) shouldBe expectedIntOption
+      }
+    }
+
+    "give means to map JsValues that can successfully be parsed as None[IntString] to None[Int]" in {
+      val optReadsStub = new Reads[Option[IntString]] {
+        def reads(jsValue: JsValue): JsResult[Option[IntString]] = JsSuccess(None)
+      }
+
+      val intermediateReads: Reads[Option[Int]] = optReadsStub.int
+      JsString("foo").as[Option[Int]](intermediateReads) shouldBe None
+    }
+
+    "give means to map JsValues that can successfully be parsed as Some[IntString] to Some[String]" in {
+      forAll { int: Int =>
+        val expectedStrOption = Some(int.toString)
+
+        val optReadsStub = new Reads[Option[IntString]] {
+          def reads(jsValue: JsValue): JsResult[Option[IntString]] = JsSuccess(Some(IntString(int)))
+        }
+
+        val intermediateReads: Reads[Option[String]] = optReadsStub.str
+        JsString("foo").as[Option[String]](intermediateReads) shouldBe expectedStrOption
+      }
+    }
+
+    "give means to map JsValues that can successfully be parsed as None[IntString] to None[String]" in {
+      val optReadsStub = new Reads[Option[IntString]] {
+        def reads(jsValue: JsValue): JsResult[Option[IntString]] = JsSuccess(None)
+      }
+
+      val intermediateReads: Reads[Option[String]] = optReadsStub.str
+      JsString("foo").as[Option[String]](intermediateReads) shouldBe None
+    }
+  }
+
+  "writes" should {
+    "output IntString as JsString" in {
+      forAll { int: Int =>
+        val intString = IntString(int)
+        Json.toJson(intString) shouldBe JsString(int.toString)
+      }
+    }
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/JsoupHelpers.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/JsoupHelpers.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import play.twirl.api.Html
+
+trait JsoupHelpers {
+
+  implicit class RichHtml(html: Html) {
+    def select(cssQuery: String): Elements =
+      parseNoPrettyPrinting(html).select(cssQuery)
+  }
+
+  // otherwise Jsoup inserts linefeed https://stackoverflow.com/questions/12503117/jsoup-line-feed
+  def parseNoPrettyPrinting(html: Html): Document = {
+    val doc = Jsoup.parse(html.body)
+    doc.outputSettings().prettyPrint(false)
+    doc
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/PreProcessor.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/PreProcessor.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import com.googlecode.htmlcompressor.compressor.HtmlCompressor
+import com.googlecode.htmlcompressor.compressor.HtmlCompressor._
+import org.jsoup.parser.Parser
+
+trait PreProcessor {
+
+  private lazy val compressor = new HtmlCompressor()
+
+  /***
+    * Compresses markup to remove irrelevant whitespace differences.
+    *
+    * @param html
+    * @return
+    */
+  def parseAndCompressHtml(html: String): String = {
+    compressor.setRemoveSurroundingSpaces(ALL_TAGS)
+    compressor.compress(Parser.unescapeEntities(html, false))
+  }
+
+  /***
+    * Function to pre-process the markup before comparing.
+    *
+    * @param html
+    * @return String
+    */
+  def preProcess(html: String): String = parseAndCompressHtml(html: String)
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/TemplateDiff.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/TemplateDiff.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import java.nio.file.Path
+
+import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch
+
+import scala.collection.JavaConverters._
+
+object TemplateDiff {
+
+  lazy val diffWrapper = DiffWrapper(new DiffMatchPatch())
+
+  /** Compute the diff and print the path to the diff file
+    *
+    * @param nunJucksOutputHtml
+    * @param twirlOutputHtml
+    * @param diffFilePrefix
+    */
+  def templateDiffPath(twirlOutputHtml: String, nunJucksOutputHtml: String, diffFilePrefix: Option[String] = None): Path = {
+    val diffResult = diffWrapper.diff(twirlOutputHtml, nunJucksOutputHtml)
+    val path       = diffWrapper.diffToHtml(diff = diffResult.asScala, diffFilePrefix = diffFilePrefix)
+    path
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/TemplateUnitSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/TemplateUnitSpec.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import better.files._
+import org.scalatest.{Matchers, TryValues, WordSpecLike}
+import uk.gov.hmrc.hmrcfrontend.views.HmrcFrontendDependency.hmrcFrontendVersion
+import play.api.libs.json._
+
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Base class for unit testing against test fixtures generated from govuk-frontend's yaml documentation files for
+  * components
+  *
+  * @param hmrcComponentName
+  * @param [[Reads[T]]]
+  * @tparam T
+  */
+abstract class TemplateUnitSpec[T: Reads](hmrcComponentName: String)
+    extends TwirlRenderer[T]
+    with PreProcessor
+    with JsoupHelpers
+    with WordSpecLike
+    with Matchers
+    with TryValues {
+
+  exampleNames(hmrcComponentName)
+    .foreach { exampleName =>
+    s"$exampleName" should {
+      "render the same html as the nunjucks renderer" in {
+        val tryTwirlHtml = renderExample(exampleName)
+
+        tryTwirlHtml match {
+          case Success(twirlHtml) =>
+            val preProcessedTwirlHtml    = preProcess(twirlHtml)
+            val preProcessedNunjucksHtml = preProcess(nunjucksHtml(exampleName).success.value)
+
+            preProcessedTwirlHtml shouldBe preProcessedNunjucksHtml
+          case Failure(TemplateValidationException(message)) =>
+            println(s"Failed to validate the parameters for the $hmrcComponentName template")
+            println(s"Exception: $message")
+            println(s"Skipping test $exampleName")
+
+            succeed
+          case Failure(exception) => fail(exception)
+        }
+      }
+    }
+  }
+
+  private def renderExample(exampleName: String): Try[String] =
+    for {
+      inputJson    <- Try(readInputJson(exampleName))
+      inputJsValue <- Try(Json.parse(inputJson))
+      html <- inputJsValue.validate[T] match {
+               case JsSuccess(templateParams, _) =>
+                 render(templateParams)
+                   .transform(html => Success(html.body), f => Failure(new TemplateValidationException(f.getMessage)))
+               case e: JsError =>
+                 throw new RuntimeException(s"Failed to validate Json params: [$inputJsValue]\nException: [$e]")
+             }
+    } yield html
+
+  private def nunjucksHtml(exampleName: String): Try[String] =
+    Try(readOutputFile(exampleName))
+
+  /**
+    * Traverse the test fixtures directory to fetch all examples for a given component
+    *
+    * @param govukComponentName govuk component name as found in the test fixtures file component.json
+    * @return [[Seq[String]]] of folder names for each example in the test fixtures folder or
+    *        fails if the fixtures folder is not defined
+    */
+  private def exampleNames(govukComponentName: String): Seq[String] = {
+    val exampleFolders = getExampleFolders(govukComponentName)
+
+    val examples = exampleFolders.map(_.name)
+
+    if (examples.nonEmpty) examples
+    else throw new RuntimeException(s"Couldn't find component named $govukComponentName. Spelling error?")
+  }
+
+  private def getExampleFolders(govukComponentName: String): Seq[File] = {
+    def parseComponentName(json: String): Option[String] = (Json.parse(json) \ "name").asOpt[String]
+
+    val componentNameFiles = fixturesDir.listRecursively.filter(_.name == "component.json")
+
+    val matchingFiles =
+      componentNameFiles.filter(file => parseComponentName(file.contentAsString).contains(govukComponentName))
+
+    val folders = matchingFiles.map(_.parent).toSeq.distinct
+
+    folders
+  }
+
+  private lazy val fixturesDir: File = {
+    val dir = s"/fixtures/test-fixtures-$hmrcFrontendVersion"
+    Try(File(Resource.my.getUrl(dir)))
+      .getOrElse(throw new RuntimeException(s"Test fixtures folder not found: $dir"))
+  }
+
+  private def readOutputFile(exampleName: String): String =
+    (fixturesDir / exampleName / "output.html").contentAsString
+
+  private def readInputJson(exampleName: String): String =
+    (fixturesDir / exampleName / "input.json").contentAsString
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/TemplateValidationException.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/TemplateValidationException.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+class TemplateValidationException(message: String) extends IllegalArgumentException(message)
+
+object TemplateValidationException {
+  def unapply(arg: TemplateValidationException): Option[String] =
+    Some(arg.getMessage)
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/TwirlRenderer.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/TwirlRenderer.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import play.twirl.api.HtmlFormat
+
+import scala.util.Try
+
+trait TwirlRenderer[T] {
+  /**
+    * Calls the Twirl template with the given parameters and returns the resulting markup
+    *
+    * @param templateParams
+    * @return [[Try[HtmlFormat.Appendable]]] containing the markup
+    */
+  def render(templateParams: T): Try[HtmlFormat.Appendable]
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/UtilsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/UtilsSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+
+import org.scalacheck._
+import org.scalatest.{Matchers, WordSpec}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.twirl.api.{Html, HtmlFormat}
+import uk.gov.hmrc.hmrcfrontend.views.Utils._
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.Generators._
+
+class UtilsSpec extends WordSpec with Matchers with ScalaCheckPropertyChecks with ShrinkLowPriority {
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 50)
+
+  "toClasses" should {
+    "concatenate existing classes with classes with a single whitespace separator if classes are not empty" in {
+      forAll(Gen.alphaStr.suchThat(_.trim.nonEmpty), Gen.alphaStr) { (existingClass, classes) =>
+        (existingClass, classes) match {
+          case (_, "") => toClasses(existingClass, classes) shouldBe existingClass
+          case _       => toClasses(existingClass, classes) shouldBe s"$existingClass $classes"
+        }
+      }
+    }
+  }
+
+  "toAttributes" should {
+    "generate attributes HTML with the required padding" in {
+      forAll(genAttributes(), Gen.chooseNum(0, 5)) { (attrsMap, padCount) =>
+        (attrsMap.toSeq, padCount) match {
+          case (Nil, _) => toAttributes(attrsMap, padCount)                 shouldBe HtmlFormat.empty
+          case (_, 0)   => toAttributes(attrsToMap(toAttributes(attrsMap))) shouldBe toAttributes(attrsMap)
+          case (_, n)   => toAttributes(attrsMap, n).body.drop(1)           shouldBe toAttributes(attrsMap, n - 1).body
+        }
+      }
+    }
+
+    def attrsToMap(html: Html): Map[String, String] = {
+      val attrs: List[List[String]] =
+        html.body.trim.split(" ").toList.map(_.split("=").toList)
+      attrs.map {
+        case attr :: value :: _ => attr -> value.replace("\"", "")
+        case x                  => throw new IllegalArgumentException(s"expecting list of 2, instead got: $x")
+      }.toMap
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/Generators.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/Generators.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels
+
+import org.scalacheck.{Arbitrary, Gen}
+import play.twirl.api.{Html, HtmlFormat}
+
+object Generators {
+
+  val genNonEmptyAlphaStr: Gen[String] = Gen.alphaStr.suchThat(_.nonEmpty)
+
+  /**
+    * Generates an alphabetic String with adjustable empty frequency String.
+    * @param emptyFreq as a percentage (0 - 100)
+    * @return
+    */
+  def genAlphaStr(emptyFreq: Int = 25): Gen[String] =
+    Gen.frequency((100 - emptyFreq, Gen.alphaStr), (emptyFreq, Gen.const("")))
+
+  val genAttrVal: Gen[(String, String)] = for {
+    attr  <- genNonEmptyAlphaStr
+    value <- genNonEmptyAlphaStr
+  } yield (attr, value)
+
+  def genAttributes(nAttributes: Int = 5) =
+    for {
+      sz         <- Gen.chooseNum(0, nAttributes)
+      attributes <- Gen.mapOfN[String, String](sz, genAttrVal)
+    } yield attributes
+
+  val genHtmlString: Gen[String] =
+    Gen.oneOf(Gen.const("""<p>some paragraph</p>"""), Gen.const(""""<b>Back</b>""""))
+
+  implicit val arbHtml: Arbitrary[Html] = Arbitrary {
+    for {
+      htmlString <- genHtmlString
+      html       <- Gen.frequency((80, Html(htmlString)), (20, HtmlFormat.empty))
+    } yield html
+  }
+
+  def genClasses(nClasses: Int = 3): Gen[String] =
+    for {
+      sz      <- Gen.chooseNum(0, nClasses)
+      classes <- Gen.listOfN(sz, Gen.alphaStr.suchThat(_.trim.nonEmpty)).map(_.mkString(" "))
+    } yield classes
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/JsonImplicitsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/JsonImplicitsSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels
+
+import org.scalacheck.{Gen, ShrinkLowPriority}
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.libs.json._
+import JsonImplicits._
+
+class JsonImplicitsSpec
+  extends WordSpec
+    with Matchers
+    with OptionValues
+    with ScalaCheckPropertyChecks
+    with ShrinkLowPriority {
+
+  "readsJsValueToString" should {
+    "deserialize any value as a String" in {
+      import Generators._
+
+      val reads = (__ \ "field").readsJsValueToString
+
+      forAll(genJsValue) { jsValue =>
+        val json = Json.obj("field" -> jsValue)
+
+        json.validate[String](reads).asOpt.value shouldBe (jsValue match {
+          case JsString(s) => s
+          case x           => x.toString
+        })
+      }
+    }
+  }
+
+  object Generators {
+    val genJsString = for (s <- Gen.alphaStr) yield JsString(s)
+
+    val genJsNumber = for (n <- Gen.choose(0, 1000)) yield JsNumber(n)
+
+    val genJsValue =
+      Gen.frequency(
+        (50, genJsString),
+        (50, genJsNumber)
+      )
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/JsonRoundtripSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/JsonRoundtripSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels
+
+import org.scalacheck.{Arbitrary, ShrinkLowPriority}
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.libs.json.{Json, Reads, Writes}
+
+import scala.reflect.ClassTag
+
+class JsonRoundtripSpec[T: Reads: Writes: Arbitrary: ClassTag]
+    extends WordSpec
+    with Matchers
+    with OptionValues
+    with ScalaCheckPropertyChecks
+    with ShrinkLowPriority {
+
+  "Json reads/writes" should {
+    s"do a roundtrip json serialisation of ${implicitly[ClassTag[T]]}" in {
+      forAll { v: T =>
+        Json.toJson[T](v).asOpt[T].value shouldBe v
+      }
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/content/ContentSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/content/ContentSpec.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.content
+
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.JsonRoundtripSpec
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.content.Generators._
+
+class ContentSpec extends JsonRoundtripSpec[Content]

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/content/Generators.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/content/Generators.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.content
+
+import org.scalacheck.{Arbitrary, Gen}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.Generators.{arbHtml, genHtmlString}
+
+object Generators {
+
+  implicit val arbEmpty: Arbitrary[Empty.type] = Arbitrary { Gen.const(Empty) }
+
+  implicit val arbHtmlContent: Arbitrary[HtmlContent] = Arbitrary {
+    arbHtml.arbitrary.map(HtmlContent(_))
+  }
+
+  implicit val arbText: Arbitrary[Text] = Arbitrary {
+    Gen.frequency((80, Gen.asciiPrintableStr), (20, genHtmlString)).map(Text)
+  }
+
+  implicit val arbContent: Arbitrary[Content] = Arbitrary {
+    Gen.oneOf(arbEmpty.arbitrary, arbHtmlContent.arbitrary, arbText.arbitrary)
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/pageheading/Generators.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/pageheading/Generators.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.pageheading
+
+import org.scalacheck.{Arbitrary, Gen}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.Generators._
+
+object Generators {
+
+  implicit val arbAccordion: Arbitrary[PageHeading] = Arbitrary {
+    for {
+      text    <- genAlphaStr()
+      section <- Gen.option(genAlphaStr())
+    } yield PageHeading(text = text, section = section)
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/pageheading/PageHeadingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/pageheading/PageHeadingSpec.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.pageheading
+
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.JsonRoundtripSpec
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.pageheading.Generators._
+
+class PageHeadingSpec extends JsonRoundtripSpec[PageHeading]


### PR DESCRIPTION
Initially just for PageHeading.

This allows HMRC service teams to access the
resources provided in Nunjucks in the
hmrc-frontend repo as Twirl instead.