### PR TITLE
PLATUI-336 Make Cy and En case objects in own files

### DIFF
--- a/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcAccountMenu.scala.html
+++ b/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcAccountMenu.scala.html
@@ -1,18 +1,6 @@
-@*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+
+
+
 
 @(params: AccountMenu)
 @import params._

--- a/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcBanner.scala.html
+++ b/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcBanner.scala.html
@@ -1,18 +1,6 @@
-@*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+
+
+
 
 @(params: Banner)
 @import params._

--- a/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcHeader.scala.html
+++ b/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcHeader.scala.html
@@ -1,18 +1,6 @@
-@*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+
+
+
 
 @(params: Header)
 @import params._

--- a/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcInternalHeader.scala.html
+++ b/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcInternalHeader.scala.html
@@ -1,18 +1,6 @@
-@*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+
+
+
 
 @(params: InternalHeader)
 @import params._

--- a/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcLanguageSelect.scala.html
+++ b/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcLanguageSelect.scala.html
@@ -1,18 +1,6 @@
-@*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+
+
+
 
 @(params: LanguageSelect)
 @import params._

--- a/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcNewTabLink.scala.html
+++ b/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcNewTabLink.scala.html
@@ -1,18 +1,6 @@
-@*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+
+
+
 
 @(params: NewTabLink)
 @import params._

--- a/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcNotificationBadge.scala.html
+++ b/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcNotificationBadge.scala.html
@@ -1,18 +1,6 @@
-@*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+
+
+
 
 @(params: NotificationBadge = NotificationBadge())
 @import params._

--- a/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeading.scala.html
+++ b/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcPageHeading.scala.html
@@ -1,18 +1,6 @@
-@*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+
+
+
 
 @(params: PageHeading)
 @import params._

--- a/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcTimeoutDialog.scala.html
+++ b/src/main/play-25/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcTimeoutDialog.scala.html
@@ -1,18 +1,6 @@
-@*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+
+
+
 
 @(params: TimeoutDialog)
 @import params._

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Aliases.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Aliases.scala
@@ -29,9 +29,9 @@ trait Aliases {
   type CheckProgress = viewmodels.accountmenu.CheckProgress
   val CheckProgress = viewmodels.accountmenu.CheckProgress
 
-  val Cy = viewmodels.language.Language.Cy
+  val Cy = viewmodels.language.Cy
 
-  val En = viewmodels.language.Language.En
+  val En = viewmodels.language.En
 
   type Header = viewmodels.header.Header
   val Header = viewmodels.header.Header

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/accountmenu/AccountMenu.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/accountmenu/AccountMenu.scala
@@ -18,8 +18,7 @@ package uk.gov.hmrc.hmrcfrontend.views.viewmodels.accountmenu
 
 import play.api.libs.json._
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.JsonDefaultValueFormatter
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language.En
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{En, Language}
 
 case class AccountMenu(
                         accountHome: AccountHome = AccountHome(),

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/header/Header.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/header/Header.scala
@@ -19,28 +19,26 @@ package uk.gov.hmrc.hmrcfrontend.views.viewmodels.header
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.JsonDefaultValueFormatter
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language.{Cy, En}
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.LanguageToggle
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{Cy, En, Language, LanguageToggle}
 
 import scala.collection.immutable.SortedMap
 
 case class Header(
-  homepageUrl: String                                     = "/",
-  assetsPath: String                                      = "/assets/images",
-  productName: Option[String]                             = None,
-  serviceName: Option[String]                             = None,
-  serviceUrl: String                                      = "",
-  navigation: Iterable[NavigationItem]                    = Iterable.empty,
-  navigationClasses: String                               = "",
-  containerClasses: String                                = "govuk-width-container",
-  classes: String                                         = "",
-  attributes: Map[String, String]                         = Map.empty,
-  language: Language                                      = En,
-  displayHmrcBanner: Boolean                              = false,
-  signOutHref: Option[String]                             = None,
-  private val inputLanguageToggle: Option[LanguageToggle] = None
-) {
+                   homepageUrl: String = "/",
+                   assetsPath: String = "/assets/images",
+                   productName: Option[String] = None,
+                   serviceName: Option[String] = None,
+                   serviceUrl: String = "",
+                   navigation: Iterable[NavigationItem] = Iterable.empty,
+                   navigationClasses: String = "",
+                   containerClasses: String = "govuk-width-container",
+                   classes: String = "",
+                   attributes: Map[String, String] = Map.empty,
+                   language: Language = En,
+                   displayHmrcBanner: Boolean = false,
+                   signOutHref: Option[String] = None,
+                   private val inputLanguageToggle: Option[LanguageToggle] = None
+                 ) {
 
   // We use this method instead of using the input language toggle directly
   // as the version in `hmrc-frontend` is less flexible, and sets a default
@@ -75,7 +73,7 @@ object Header extends JsonDefaultValueFormatter[Header] {
         (__ \ "displayHmrcBanner").read[Boolean] and
         (__ \ "signOutHref").readNullable[String] and
         (__ \ "languageToggle").readNullable[LanguageToggle]
-    )(Header.apply _)
+      ) (Header.apply _)
 
   override implicit def jsonWrites: OWrites[Header] =
     (
@@ -93,5 +91,5 @@ object Header extends JsonDefaultValueFormatter[Header] {
         (__ \ "displayHmrcBanner").write[Boolean] and
         (__ \ "signOutHref").writeNullable[String] and
         (__ \ "languageToggle").writeNullable[LanguageToggle]
-    )(header => unlift(Header.unapply)(header.copy(inputLanguageToggle = header.languageToggle)))
+      ) (header => unlift(Header.unapply)(header.copy(inputLanguageToggle = header.languageToggle)))
 }

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/Cy.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/Cy.scala
@@ -14,21 +14,9 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.hmrcfrontend.views.viewmodels.banner
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.language
 
-import play.api.libs.json._
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.JsonDefaultValueFormatter
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{En, Language}
-
-case class Banner(
-                   language: Language = En
-                 )
-
-object Banner extends JsonDefaultValueFormatter[Banner] {
-
-  override def defaultObject: Banner = Banner()
-
-  override def defaultReads: Reads[Banner] = Json.reads[Banner]
-
-  override implicit def jsonWrites: OWrites[Banner] = Json.writes[Banner]
+case object Cy extends Language {
+  val code: String = "cy"
+  val name: String = "Cymraeg"
 }

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/En.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/En.scala
@@ -14,21 +14,9 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.hmrcfrontend.views.viewmodels.banner
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.language
 
-import play.api.libs.json._
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.JsonDefaultValueFormatter
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{En, Language}
-
-case class Banner(
-                   language: Language = En
-                 )
-
-object Banner extends JsonDefaultValueFormatter[Banner] {
-
-  override def defaultObject: Banner = Banner()
-
-  override def defaultReads: Reads[Banner] = Json.reads[Banner]
-
-  override implicit def jsonWrites: OWrites[Banner] = Json.writes[Banner]
+case object En extends Language {
+  val code: String = "en"
+  val name: String = "English"
 }

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/Language.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/Language.scala
@@ -18,45 +18,39 @@ package uk.gov.hmrc.hmrcfrontend.views.viewmodels.language
 
 import play.api.libs.json._
 
-sealed trait Language extends Ordered[Language] {
+trait Language extends Ordered[Language] {
   def code: String
+
   def name: String
 
-  override def compare(that: Language): Int = {
-    import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language.En
-    (this, that) match {
-      case (En, En)  => 0
-      case (En, _)   => -1
-      case (_, En)   => 1
-      case (_, _)    => this.name compare that.name
-    }
-  }
+  def compare(that: Language): Int = Language.LanguageOrdering.compare(this, that)
 }
 
 object Language {
-
-  object Cy extends Language {
-    val code: String = "cy"
-    val name: String = "Cymraeg"
-  }
-
-  object En extends Language {
-    val code: String = "en"
-    val name: String = "English"
-  }
 
   implicit object LanguageFormat extends Format[Language] {
     override def reads(json: JsValue): JsResult[Language] = json match {
       case JsString("en") => JsSuccess(En)
       case JsString("cy") => JsSuccess(Cy)
-      case JsString(_) => JsError("error.expected.validlanguage")
-      case _ => JsError("error.expected.jsstring")
+      case JsString(_)    => JsError("error.expected.validlanguage")
+      case _              => JsError("error.expected.jsstring")
     }
 
     override def writes(o: Language): JsString = JsString(o match {
       case Cy => "cy"
       case En => "en"
     })
+  }
+
+  implicit object LanguageOrdering extends Ordering[Language] { // Ordered/Ordering are invariant in type parameters, so cannot be mixed into trait to order implementations of the trait
+    def compare(x: Language, y: Language): Int = {
+      (x, y) match {
+        case (En, En) => 0
+        case (En, _)  => -1
+        case (_, En)  => 1
+        case (_, _)   => x.name compare y.name
+      }
+    }
   }
 
 }

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/LanguageSelect.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/LanguageSelect.scala
@@ -17,10 +17,8 @@
 package uk.gov.hmrc.hmrcfrontend.views.viewmodels.language
 
 import play.api.libs.json._
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language.LanguageFormat
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language.{Cy, En}
 
-import scala.collection.immutable.SortedMap
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language.LanguageFormat
 
 case class LanguageSelect(language: Language, private val languageLinks: (Language, String)*) {
 
@@ -31,8 +29,7 @@ case class LanguageSelect(language: Language, private val languageLinks: (Langua
   // This behaviour is mirrored here both to pass the unit tests and to
   // maintain parity with `hmrc-frontend`.
   val languageToggle: LanguageToggle = {
-    val inputLangLinks = SortedMap[Language, String](languageLinks.toArray: _*)
-    val linkMapWithDefaults: SortedMap[Language, String] = SortedMap(En -> "", Cy -> "") ++ inputLangLinks
+    val linkMapWithDefaults: Map[Language, String] = Map(En -> "", Cy -> "") ++ languageLinks
     LanguageToggle(linkMapWithDefaults.toArray: _*)
   }
 

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/header/HeaderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/header/HeaderSpec.scala
@@ -21,10 +21,8 @@ import org.scalacheck.ShrinkLowPriority
 import org.scalatest.{Matchers, OptionValues, WordSpec}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.libs.json.Json
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.LanguageToggle
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language.{Cy, En}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{Cy, En, LanguageToggle}
 
-import scala.collection.immutable.SortedMap
 import scala.reflect.ClassTag
 
 // We use this customised test class as the `hmrc-frontend` Nunjucks model
@@ -46,7 +44,12 @@ class HeaderSpec
   "Json reads/writes" should {
     s"do a roundtrip json serialisation of ${implicitly[ClassTag[Header]]}" in {
       forAll { v: Header =>
-        val linkMapWithDefaults: Option[LanguageToggle] = v.languageToggle.map(x => LanguageToggle(SortedMap(En -> "", Cy -> "") ++ x.linkMap))
+        val linkMapWithDefaults: Option[LanguageToggle] = v.languageToggle.map {
+          x => {
+            val links = Map(En -> "", Cy -> "") ++ x.linkMap
+            LanguageToggle(links.toArray: _*)
+          }
+        }
         Json.toJson(v).asOpt[Header].value shouldBe v.copy(inputLanguageToggle = linkMapWithDefaults)
       }
     }

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/Generators.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/Generators.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.hmrcfrontend.views.viewmodels.language
 
 import org.scalacheck.{Arbitrary, Gen}
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.Generators._
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language.{Cy, En}
 
 object Generators {
 

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/LanguageSelectSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/LanguageSelectSpec.scala
@@ -21,9 +21,7 @@ import org.scalacheck.ShrinkLowPriority
 import org.scalatest.{Matchers, OptionValues, WordSpec}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.libs.json.Json
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language.{Cy, En}
 
-import scala.collection.immutable.SortedMap
 import scala.reflect.ClassTag
 
 // We use this customised test class as the `hmrc-frontend` Nunjucks model
@@ -44,7 +42,7 @@ class LanguageSelectSpec
   "Json reads/writes" should {
     s"do a roundtrip json serialisation of ${implicitly[ClassTag[LanguageSelect]]}" in {
       forAll { v: LanguageSelect =>
-        val linkMapWithDefaults: SortedMap[Language, String] = SortedMap(En -> "", Cy -> "") ++ v.languageToggle.linkMap
+        val linkMapWithDefaults: Map[Language, String] = Map(En -> "", Cy -> "") ++ v.languageToggle.linkMap
         Json.toJson(v).asOpt[LanguageSelect].value shouldBe LanguageSelect(v.language, linkMapWithDefaults.toArray: _*)
       }
     }

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/LanguageSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/language/LanguageSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.hmrcfrontend.views.viewmodels.language
 
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.JsonRoundtripSpec
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Generators._
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language.{Cy, En}
 
 class LanguageSpec extends JsonRoundtripSpec[Language] {
 


### PR DESCRIPTION
- Ensures uniform behaviour with other view models.
- Some methods changed to account for Ordering[Language] and mixing in of the trait that implements this.