### PR TITLE
PLATUI-442: add hmrcAddToAList component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.62.0] - 2021-05-10
+
+### Added
+
+- hmrcAddToAList component
+
 ## [0.61.0] - 2021-05-10
 
 ### Changed

--- a/src/it/scala/uk/gov/hmrc/hmrcfrontend/views/components/hmrcAddToAListSpec.scala
+++ b/src/it/scala/uk/gov/hmrc/hmrcfrontend/views/components/hmrcAddToAListSpec.scala
@@ -1,0 +1,17 @@
+package uk.gov.hmrc.hmrcfrontend.views.components
+
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.hmrcfrontend.MessagesSupport
+import uk.gov.hmrc.hmrcfrontend.support.TemplateIntegrationSpec
+import uk.gov.hmrc.hmrcfrontend.views.html.components._
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist.Generators._
+
+import scala.util.Try
+
+object hmrcAddToAListSpec
+    extends TemplateIntegrationSpec[AddToAList](hmrcComponentName = "hmrcAddToAList", seed = None)
+    with MessagesSupport {
+
+  override def render(addToAList: AddToAList): Try[HtmlFormat.Appendable] =
+    Try(HmrcAddToAList(addToAList))
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Aliases.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/Aliases.scala
@@ -98,6 +98,9 @@ trait Aliases {
 
   type CharacterCount = viewmodels.charactercount.CharacterCount
   val CharacterCount = viewmodels.charactercount.CharacterCount
+
+  type AddToAList = viewmodels.addtoalist.AddToAList
+  val AddToAList = viewmodels.addtoalist.AddToAList
 }
 
 object Aliases extends Aliases

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/html/components/package.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/html/components/package.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.hmrcfrontend.views
 package html
 
-import uk.gov.hmrc.govukfrontend.views.html.components.{GovukErrorMessage, GovukHint, GovukLabel, GovukPhaseBanner, GovukTextarea}
+import uk.gov.hmrc.govukfrontend.views.html.components._
 
 package object components extends Utils with Aliases {
 
@@ -81,5 +81,9 @@ package object components extends Utils with Aliases {
   type HmrcCharacterCount = hmrcCharacterCount
   @deprecated(message = "Use DI", since = "Play 2.6")
   lazy val HmrcCharacterCount = new hmrcCharacterCount(GovukTextarea, GovukHint)
+
+  type HmrcAddToAList = hmrcAddToAList
+  @deprecated(message = "Use DI", since = "Play 2.6")
+  lazy val HmrcAddToAList = new hmrcAddToAList(GovukRadios, GovukButton)
 
 }

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/AddToAList.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/AddToAList.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{En, Language}
+
+case class AddToAList(
+  itemList: Seq[ListItem] = Seq.empty,
+  itemType: Option[ItemType] = None,
+  itemSize: ItemSize = Short,
+  formAction: Option[String] = None,
+  hintText: Option[String] = None,
+  language: Language = En
+)
+
+object AddToAList {
+  implicit def jsonFormats: OFormat[AddToAList] = Json.using[Json.WithDefaultValues].format[AddToAList]
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/ItemSize.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/ItemSize.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist
+
+import play.api.libs.json.{Format, JsError, JsResult, JsString, JsSuccess, JsValue}
+
+trait ItemSize {
+  def suffix: String
+}
+
+object ItemSize {
+  implicit object ItemSizeFormat extends Format[ItemSize] {
+    override def reads(json: JsValue): JsResult[ItemSize] = json match {
+      case JsString("short") => JsSuccess(Short)
+      case JsString("long")  => JsSuccess(Long)
+      case JsString(_)       => JsError("error.expected.validitemsize")
+      case _                 => JsError("error.expected.jsstring")
+    }
+
+    override def writes(o: ItemSize): JsString = JsString(o.suffix)
+  }
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/ItemType.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/ItemType.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist
+
+import play.api.libs.json.{Json, OFormat}
+
+case class ItemType(
+  singular: String,
+  plural: String
+)
+
+object ItemType {
+  implicit def jsonFormats: OFormat[ItemType] = Json.using[Json.WithDefaultValues].format[ItemType]
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/ListItem.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/ListItem.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist
+
+import play.api.libs.json.{Json, OFormat}
+
+case class ListItem(
+  name: String,
+  changeUrl: String,
+  removeUrl: String
+)
+
+object ListItem {
+  implicit def jsonFormats: OFormat[ListItem] = Json.using[Json.WithDefaultValues].format[ListItem]
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/Long.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/Long.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist
+
+case object Long extends ItemSize {
+  val suffix: String = "long"
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/Short.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/Short.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist
+
+case object Short extends ItemSize {
+  val suffix: String = "short"
+}

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcAddToAList.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/components/hmrcAddToAList.scala.html
@@ -1,0 +1,138 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.Aliases.Hint
+@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukButton, GovukRadios}
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.button.Button
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.{Fieldset, Legend}
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.{RadioItem, Radios}
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{Cy, En}
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist.AddToAList
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist.ItemType
+
+@this(govukRadios: GovukRadios, govukButton: GovukButton)
+
+@(params: AddToAList)(implicit messages: Messages)
+@import params._
+
+@defining(if(params.language == Cy || messages.lang.code == "cy") Cy else En) { language =>
+
+  @defining(
+    itemType.getOrElse(language match {
+      case Cy => ItemType(
+        singular = "eitem",
+        plural = "o eitemau")
+      case _ => ItemType(
+        singular = "item",
+        plural = "items"
+      )
+    })
+  ) { itemType =>
+
+    <h1 class="govuk-heading-xl">
+      @(language, itemList.length) match {
+        case (Cy, 0) => { Nid ydych wedi ychwanegu unrhyw eitemau }
+        case (_, 0) => { You have not added any items }
+        case (Cy, 1) => { Rydych wedi ychwanegu 1 @itemType.singular}
+        case (_, 1) => { You have added 1 @itemType.singular}
+        case (Cy, n) => { Rydych wedi ychwanegu @n @itemType.plural}
+        case (_, n) => { You have added @n @itemType.plural}
+      }
+    </h1>
+
+    <div class="govuk-form-group">
+      <dl class="hmrc-add-to-a-list hmrc-add-to-a-list--@itemSize.suffix">
+      @for(item <- itemList) {
+        <div class="hmrc-add-to-a-list__contents">
+          <dt class="hmrc-add-to-a-list__identifier hmrc-add-to-a-list__identifier--light">
+          @item.name
+          </dt>
+          <dd class="hmrc-add-to-a-list__change">
+            <a class="govuk-link" href="@item.changeUrl">
+              <span aria-hidden="true">@language match {
+                case Cy => { Newid }
+                case _ => { Change }
+              }</span>
+              <span class="govuk-visually-hidden">@language match {
+                case Cy => { Newid @item.name}
+                case _ => { Change @item.name}
+              }</span>
+            </a>
+          </dd>
+          <dd class="hmrc-add-to-a-list__remove">
+            <a class="govuk-link" href="@item.removeUrl">
+              <span aria-hidden="true">@language match {
+                case Cy => { Dileu }
+                case _ => { Remove }
+              }</span>
+              <span class="govuk-visually-hidden">@language match {
+                case Cy => { Dileu’r @item.name o’r rhestr }
+                case _ => { Remove @item.name from the list }
+              }</span>
+            </a>
+          </dd>
+        </div>
+      }
+      </dl>
+    </div>
+    <form method="post" action="@formAction">
+      @govukRadios(Radios(
+        fieldset = Some(Fieldset(
+          legend = Some(Legend(
+            content = Text(language match {
+              case Cy => s"Oes angen i chi ychwanegu ${itemType.singular} arall?"
+              case _ => s"Do you need to add another ${itemType.singular}?"
+            }),
+            classes = "govuk-fieldset__legend govuk-fieldset__legend--m",
+            isPageHeading = false
+          ))
+        )),
+        hint = Some(Hint(content = Text(hintText.getOrElse("")))),
+        idPrefix = Some("add-another"),
+        name = "add-another",
+        items = Seq(
+          RadioItem(
+            content = Text(language match {
+              case Cy => "Iawn"
+              case _ => "Yes"
+            }),
+            value = Some(language match {
+              case Cy => "Iawn"
+              case _ => "Yes"
+            })
+          ),
+          RadioItem(
+            content = Text(language match {
+              case Cy => "Na"
+              case _ => "No"
+            }),
+            value = Some(language match {
+              case Cy => "Na"
+              case _ => "No"
+            })
+          )
+        ),
+        classes = "govuk-radios--inline"
+      ))
+
+      @govukButton(Button(content = Text(language match {
+        case Cy => "Yn eich blaen"
+        case _ => "continue"
+      })))
+    </form>
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/components/hmrcAddToAList.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/components/hmrcAddToAList.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views
+package components
+
+import play.api.i18n.{Lang, Messages}
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.hmrcfrontend.MessagesSupport
+import uk.gov.hmrc.hmrcfrontend.views.html.components._
+
+import scala.util.Try
+
+class hmrcAddToAList extends TemplateUnitSpec[AddToAList]("hmrcAddToAList") with MessagesSupport {
+
+  /**
+    * Calls the Twirl template with the given parameters and returns the resulting markup
+    *
+    * @param templateParams
+    * @return [[Try[HtmlFormat.Appendable]]] containing the markup
+    */
+  override def render(templateParams: AddToAList): Try[HtmlFormat.Appendable] =
+    Try(HmrcAddToAList(templateParams))
+
+  "hmrcAddToAList" should {
+    "display welsh translations if viewmodel language is welsh" in {
+      val englishMessages: Messages = messagesApi.preferred(Seq(Lang("en")))
+      val addToAList                = AddToAList(language = Cy)
+
+      val content = HmrcAddToAList(addToAList)(englishMessages)
+      val heading = content.select(".govuk-heading-xl")
+
+      heading.text() shouldBe "Nid ydych wedi ychwanegu unrhyw eitemau"
+    }
+
+    "display welsh translations if implicit messages language is welsh" in {
+      val welshMessages: Messages = messagesApi.preferred(Seq(Lang("cy")))
+      val addToAList              = AddToAList(language = En)
+
+      val content = HmrcAddToAList(addToAList)(welshMessages)
+      val heading = content.select(".govuk-heading-xl")
+
+      heading.text() shouldBe "Nid ydych wedi ychwanegu unrhyw eitemau"
+    }
+
+    "display english translations if viewmodel language and implicit messages language are english" in {
+      val englishMessages: Messages = messagesApi.preferred(Seq(Lang("en")))
+      val addToAList                = AddToAList(language = En)
+
+      val content = HmrcAddToAList(addToAList)(englishMessages)
+      val heading = content.select(".govuk-heading-xl")
+
+      heading.text() shouldBe "You have not added any items"
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/AddToAListSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/AddToAListSpec.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist
+
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.JsonRoundtripSpec
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist.Generators._
+
+class AddToAListSpec extends JsonRoundtripSpec[AddToAList] {}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/Generators.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/addtoalist/Generators.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist
+
+import org.scalacheck.{Arbitrary, Gen}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.Generators.genAlphaStr
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Generators.arbLanguage
+
+object Generators {
+  implicit val arbAddToAList: Arbitrary[AddToAList] = Arbitrary {
+    for {
+      language   <- arbLanguage.arbitrary
+      hintText   <- Gen.option(genAlphaStr())
+      formAction <- Gen.option(genAlphaStr())
+      itemSize   <- Gen.oneOf(Short, Long)
+      itemType   <- Gen.option(arbItemType.arbitrary)
+      itemList   <- genListItem()
+    } yield AddToAList(
+      language = language,
+      hintText = hintText,
+      itemSize = itemSize,
+      formAction = formAction,
+      itemType = itemType,
+      itemList = itemList
+    )
+  }
+
+  implicit val arbItemType: Arbitrary[ItemType] = Arbitrary {
+    for {
+      singular <- genAlphaStr()
+      plural   <- genAlphaStr()
+    } yield ItemType(singular = singular, plural = plural)
+  }
+
+  implicit val arbListItem: Arbitrary[ListItem] = Arbitrary {
+    for {
+      name      <- genAlphaStr()
+      changeUrl <- genAlphaStr()
+      removeUrl <- genAlphaStr()
+    } yield ListItem(name = name, changeUrl = changeUrl, removeUrl = removeUrl)
+  }
+
+  def genListItem(n: Int = 5): Gen[Seq[ListItem]] = for {
+    sz    <- Gen.chooseNum(0, n)
+    items <- Gen.listOfN[ListItem](sz, arbListItem.arbitrary)
+  } yield items
+}


### PR DESCRIPTION
I've got a few questions about how to handle a dependency that I've left in as TODOs

https://github.com/hmrc/play-frontend-hmrc/compare/PLATUI-442_update-hmrc-frontend-version...PLATUI-442_add-to-a-list-component?expand=1#diff-4a7fb8b748eb4a6d5c48ad1936a81416303c12047f46c39ecf6c707bf775c15cR25-R27

but before trying to come to some consensus on those it's probably better to look at how I'm using the helper in question within the twirl template https://github.com/hmrc/play-frontend-hmrc/compare/PLATUI-442_update-hmrc-frontend-version...PLATUI-442_add-to-a-list-component?expand=1#diff-939d572314852a3ec07c66afe543de5e7fc28258227eade12bb183e197c88516
