### PR TITLE
PLATUI-1290: add page heading config helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0] - 2021-08-17
+
+### Added
+
+- Added `HmrcPageHeadingLabel` and `HmrcPageHeadingLegend` for constructing labels and legends as a hmrc heading with a
+  section as a caption, see
+  the [guidance in our readme for their usage](README.md#hmrcpageheadinglabel-and-hmrcpageheadinglegend)
+
+### Compatible with
+
+- [hmrc/hmrc-frontend v2.2.0](https://github.com/hmrc/hmrc-frontend/releases/tag/v2.2.0)
+- [hmrc/play-frontend-govuk v1.0.0](https://github.com/hmrc/play-frontend-govuk/releases/tag/v1.0.0)
+- [alphagov/govuk-frontend v3.13.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.13.0)
+
 ## [1.0.0] - 2021-08-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -304,9 +304,9 @@ These helpers let you use a label or legend as a page heading with a section (ca
 
 For example, how you could use HmrcPageHeadingLabel with a govukInput:
 ```scala
-@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukInput, Input, Hint, Text}
+@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukInput, Input, Hint, Text, Text}
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
-@import uk.gov.hmrc.hmrcfrontend.views.config.HmrcPageHeadingLabel
+@import uk.gov.hmrc.hmrcfrontend.views.config.{HmrcPageHeadingLabel, HmrcSectionCaption}
 
 @this(govukInput: GovukInput)
 
@@ -314,7 +314,7 @@ For example, how you could use HmrcPageHeadingLabel with a govukInput:
 
 @govukInput(
   Input(
-    label = HmrcPageHeadingLabel(content = Text("What is your name?"), caption = Text("Personal details")),
+    label = HmrcPageHeadingLabel(content = Text("What is your name?"), caption = HmrcSectionCaption(Text("Personal details"))),
     hint = Some(Hint(content = Text("This example shows a page heading inside a <label>")))
   ).withFormField(myForm("whatIsYourName"))
 )
@@ -332,7 +332,7 @@ For example, how you could use HmrcPageHeadingLegend with govukRadios:
 
 @govukRadios(Radios(
   fieldset = Some(Fieldset(
-    legend = Some(HmrcPageHeadingLegend(content = Text("Where do you live?"), caption = Text("Personal details"))
+    legend = Some(HmrcPageHeadingLegend(content = Text("Where do you live?"), caption = HmrcSectionCaption(Text("Personal details")))
   )), 
   hint = Some(Hint(content = Text("This example shows a page heading inside a <legend>"))),
   items = List("England", "Scotland", "Wales", "Northern Ireland") map { place =>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The library comprises two packages:
 - [Warning users before timing them out](#warning-users-before-timing-them-out)
 - [RichDateInput](#richdateinput)
 - [RichErrorSummary](#richerrorsummary)
+- [Display a caption above a page heading label or legend](#hmrcpageheadinglabel-and-hmrcpageheadinglegend)
 - [Adding your own SASS compilation pipeline](#adding-your-own-sass-compilation-pipeline)
 - [Play Framework and Scala compatibility notes](#play-framework-and-scala-compatibility-notes)
 - [Getting help](#getting-help)
@@ -296,6 +297,51 @@ Note, these methods will not overwrite any existing `ErrorSummary` properties. F
 non-empty title, it will not be overwritten.
 
 To use this class you will need to have an implicit `Messages` in scope.
+
+#### HmrcPageHeadingLabel and HmrcPageHeadingLegend
+
+These helpers let you use a label or legend as a page heading with a section (caption) displayed above it.
+
+For example, how you could use HmrcPageHeadingLabel with a govukInput:
+```scala
+@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukInput, Input, Hint, Text}
+@import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
+@import uk.gov.hmrc.hmrcfrontend.views.config.HmrcPageHeadingLabel
+
+@this(govukInput: GovukInput)
+
+@(myForm: Form[_])(implicit messages: Messages)
+
+@govukInput(
+  Input(
+    label = HmrcPageHeadingLabel(content = Text("What is your name?"), caption = Text("Personal details")),
+    hint = Some(Hint(content = Text("This example shows a page heading inside a <label>")))
+  ).withFormField(myForm("whatIsYourName"))
+)
+```
+
+For example, how you could use HmrcPageHeadingLegend with govukRadios:
+```scala
+@import uk.gov.hmrc.govukfrontend.views.html.components.{Radios, RadioItem, Fieldset, Hint, Text}
+@import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
+@import uk.gov.hmrc.hmrcfrontend.views.config.HmrcPageHeadingLegend
+
+@this(govukInput: GovukRadios)
+
+@(myForm: Form[_])(implicit messages: Messages)
+
+@govukRadios(Radios(
+  fieldset = Some(Fieldset(
+    legend = Some(HmrcPageHeadingLegend(content = Text("Where do you live?"), caption = Text("Personal details"))
+  )), 
+  hint = Some(Hint(content = Text("This example shows a page heading inside a <legend>"))),
+  items = List("England", "Scotland", "Wales", "Northern Ireland") map { place =>
+    RadioItem(
+      content = Text(place),
+      value = Some(place)
+    )
+  }).withFormField(myForm("whereDoYouLive")))
+```
 
 ### Example Templates
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin(
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.4.2")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.3.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.4.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "2.2.0")
 

--- a/src/main/resources/messages
+++ b/src/main/resources/messages
@@ -20,3 +20,4 @@ date.input.month = Month
 date.input.year = Year
 error.summary.title = There is a problem
 back.text=Back
+this.section.is=This section is

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcPageHeading.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcPageHeading.scala
@@ -41,7 +41,7 @@ object HmrcPageHeadingLabel extends HmrcPageHeading {
     classes: String = "",
     attributes: Map[String, String] = Map.empty
   ): Label = {
-    require(content.nonEmpty, "hmrcPageHeadingLabel content must not be empty")
+    require(content.nonEmpty, "HmrcPageHeadingLabel content must not be empty")
     Label(
       isPageHeading = true,
       attributes = attributes,
@@ -57,7 +57,7 @@ object HmrcPageHeadingLegend extends HmrcPageHeading {
     caption: Content = Empty,
     classes: String = ""
   ): Legend = {
-    require(content.nonEmpty, "hmrcPageHeadingLegend content must not be empty")
+    require(content.nonEmpty, "HmrcPageHeadingLegend content must not be empty")
     Legend(
       isPageHeading = false, // we build it ourselves because to include a section we need to add some extra classes
       content = HtmlContent(

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcPageHeading.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcPageHeading.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.config
+
+import play.twirl.api.{Html, HtmlFormat}
+import uk.gov.hmrc.govukfrontend.views.Utils.toClasses
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Content, Empty, HtmlContent}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Legend
+import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
+
+trait HmrcPageHeading {
+  protected def pageHeadingCaption(content: Content): Html = if (content.nonEmpty)
+    HtmlFormat.fill(
+      List(
+        Html(""" <span class="govuk-caption-xl hmrc-caption-xl">"""),
+        content.asHtml,
+        Html("</span>")
+      )
+    )
+  else content.asHtml
+}
+
+object HmrcPageHeadingLabel extends HmrcPageHeading {
+  def apply(
+    content: Content,
+    caption: Content = Empty,
+    classes: String = "",
+    attributes: Map[String, String] = Map.empty
+  ): Label = {
+    require(content.nonEmpty, "hmrcPageHeadingLabel content must not be empty")
+    Label(
+      isPageHeading = true,
+      attributes = attributes,
+      content = HtmlContent(HtmlFormat.fill(List(content.asHtml, pageHeadingCaption(caption)))),
+      classes = toClasses("govuk-label--xl hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-2", classes)
+    )
+  }
+}
+
+object HmrcPageHeadingLegend extends HmrcPageHeading {
+  def apply(
+    content: Content,
+    caption: Content = Empty,
+    classes: String = ""
+  ): Legend = {
+    require(content.nonEmpty, "hmrcPageHeadingLegend content must not be empty")
+    Legend(
+      isPageHeading = false, // we build it ourselves because to include a section we need to add some extra classes
+      content = HtmlContent(
+        HtmlFormat.fill(
+          List(
+            Html(
+              """<h1 class="govuk-fieldset__heading hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-0">"""
+            ),
+            content.asHtml,
+            pageHeadingCaption(caption),
+            Html("</h1>")
+          )
+        )
+      ),
+      classes = toClasses("govuk-fieldset__legend--xl", classes)
+    )
+  }
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcSectionCaption.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcSectionCaption.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.config
+
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Content, HtmlContent}
+
+object HmrcSectionCaption {
+  def apply(
+    section: Content
+  )(implicit messages: Messages): Content =
+    HtmlContent(
+      s"""<span class="govuk-visually-hidden">${messages("this.section.is")}</span>${section.asHtml}"""
+    )
+}

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcSectionCaption.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcSectionCaption.scala
@@ -17,13 +17,18 @@
 package uk.gov.hmrc.hmrcfrontend.views.config
 
 import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Content, HtmlContent}
 
 object HmrcSectionCaption {
   def apply(
     section: Content
-  )(implicit messages: Messages): Content =
+  )(implicit messages: Messages): Content = {
+    require(section.nonEmpty, "HmrcSectionCaption section must not be empty")
     HtmlContent(
-      s"""<span class="govuk-visually-hidden">${messages("this.section.is")}</span>${section.asHtml}"""
+      s"""<span class="govuk-visually-hidden">${HtmlFormat.escape(
+        messages("this.section.is")
+      )} </span>${section.asHtml}"""
     )
+  }
 }

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/components/HmrcHeader.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/components/HmrcHeader.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.phasebanner.PhaseBanner
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukPhaseBanner
 
 @this(hmrcBanner: HmrcBanner, hmrcUserResearchBanner: HmrcUserResearchBanner, govukPhaseBanner: GovukPhaseBanner)

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcLayout.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcLayout.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukLayout
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukBackLink
 @import uk.gov.hmrc.govukfrontend.views.html.components.TwoThirdsMainContent

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcPageHeadingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcPageHeadingSpec.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.config
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Legend
+import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
+
+class HmrcPageHeadingSpec extends AnyWordSpec with Matchers {
+
+  "HmrcPageHeadingLabel" must {
+    "construct expected label view model" in {
+      HmrcPageHeadingLabel(content = Text("What is your name?"), caption = Text("Personal details")) mustBe Label(
+        isPageHeading = true,
+        content = HtmlContent(
+          """What is your name? """
+            + """<span class="govuk-caption-xl hmrc-caption-xl">"""
+            + """Personal details"""
+            + """</span>"""
+        ),
+        classes = "govuk-label--xl hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-2"
+      )
+    }
+
+    "allow caption to be empty" in {
+      HmrcPageHeadingLabel(content = Text("What is your name?")) mustBe Label(
+        isPageHeading = true,
+        content = HtmlContent(
+          """What is your name?"""
+        ),
+        classes = "govuk-label--xl hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-2"
+      )
+    }
+
+    "accept custom classes and attributes" in {
+      HmrcPageHeadingLabel(
+        content = Text("What is your name?"),
+        caption = Text("Personal details"),
+        classes = "foo bar",
+        attributes = Map("foo" -> "bar")
+      ) mustBe Label(
+        isPageHeading = true,
+        content = HtmlContent(
+          """What is your name? """
+            + """<span class="govuk-caption-xl hmrc-caption-xl">"""
+            + """Personal details"""
+            + """</span>"""
+        ),
+        classes = "govuk-label--xl hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-2 foo bar",
+        attributes = Map("foo" -> "bar")
+      )
+    }
+
+    "escape unsafe html output" in {
+      HmrcPageHeadingLabel(
+        content = Text("<page-title>"),
+        caption = Text("<page-section>")
+      ) mustBe Label(
+        isPageHeading = true,
+        content = HtmlContent(
+          """&lt;page-title&gt; """
+            + """<span class="govuk-caption-xl hmrc-caption-xl">"""
+            + """&lt;page-section&gt;"""
+            + """</span>"""
+        ),
+        classes = "govuk-label--xl hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-2"
+      )
+    }
+
+    "not escape safe html output" in {
+      HmrcPageHeadingLabel(
+        content = HtmlContent("<page-title>"),
+        caption = HtmlContent("<page-section>")
+      ) mustBe Label(
+        isPageHeading = true,
+        content = HtmlContent(
+          """<page-title> """
+            + """<span class="govuk-caption-xl hmrc-caption-xl">"""
+            + """<page-section>"""
+            + """</span>"""
+        ),
+        classes = "govuk-label--xl hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-2"
+      )
+    }
+
+    "require content to be non empty" in {
+      try {
+        HmrcPageHeadingLabel(
+          content = Text("")
+        )
+        fail("construction succeeded with empty text")
+      } catch {
+        case e: IllegalArgumentException => // pass
+      }
+    }
+  }
+
+  "HmrcPageHeadingLegend" must {
+    "construct expected legend view model" in {
+      HmrcPageHeadingLegend(content = Text("Where do you live?"), caption = Text("Personal details")) mustBe Legend(
+        isPageHeading = false,
+        content = HtmlContent(
+          """<h1 class="govuk-fieldset__heading hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-0">"""
+            + """Where do you live? """
+            + """<span class="govuk-caption-xl hmrc-caption-xl">"""
+            + """Personal details"""
+            + """</span>"""
+            + """</h1>"""
+        ),
+        classes = "govuk-fieldset__legend--xl"
+      )
+    }
+
+    "allow caption to be empty" in {
+      HmrcPageHeadingLegend(content = Text("Where do you live?")) mustBe Legend(
+        isPageHeading = false,
+        content = HtmlContent(
+          """<h1 class="govuk-fieldset__heading hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-0">"""
+            + """Where do you live?"""
+            + """</h1>"""
+        ),
+        classes = "govuk-fieldset__legend--xl"
+      )
+    }
+
+    "accept custom classes" in {
+      HmrcPageHeadingLegend(
+        content = Text("Where do you live?"),
+        caption = Text("Personal details"),
+        classes = "foo bar"
+      ) mustBe Legend(
+        isPageHeading = false,
+        classes = "govuk-fieldset__legend--xl foo bar",
+        content = HtmlContent(
+          """<h1 class="govuk-fieldset__heading hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-0">"""
+            + """Where do you live? """
+            + """<span class="govuk-caption-xl hmrc-caption-xl">"""
+            + """Personal details"""
+            + """</span>"""
+            + """</h1>"""
+        )
+      )
+    }
+
+    "escape unsafe html output" in {
+      HmrcPageHeadingLegend(
+        content = Text("<page-title>"),
+        caption = Text("<page-section>")
+      ) mustBe Legend(
+        isPageHeading = false,
+        classes = "govuk-fieldset__legend--xl",
+        content = HtmlContent(
+          """<h1 class="govuk-fieldset__heading hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-0">"""
+            + """&lt;page-title&gt; """
+            + """<span class="govuk-caption-xl hmrc-caption-xl">"""
+            + """&lt;page-section&gt;"""
+            + """</span>"""
+            + """</h1>"""
+        )
+      )
+    }
+
+    "not escape safe html output" in {
+      HmrcPageHeadingLegend(
+        content = HtmlContent("<page-title>"),
+        caption = HtmlContent("<page-section>")
+      ) mustBe Legend(
+        isPageHeading = false,
+        classes = "govuk-fieldset__legend--xl",
+        content = HtmlContent(
+          """<h1 class="govuk-fieldset__heading hmrc-page-heading govuk-!-margin-top-0 govuk-!-margin-bottom-0">"""
+            + """<page-title> """
+            + """<span class="govuk-caption-xl hmrc-caption-xl">"""
+            + """<page-section>"""
+            + """</span>"""
+            + """</h1>"""
+        )
+      )
+    }
+
+    "require content to be non empty" in {
+      try {
+        HmrcPageHeadingLegend(
+          content = Text("")
+        )
+        fail("construction succeeded with empty text")
+      } catch {
+        case e: IllegalArgumentException => // pass
+      }
+    }
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcSectionCaptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcSectionCaptionSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.config
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.i18n.{DefaultLangs, Lang, MessagesApi}
+import play.api.test.Helpers.stubMessagesApi
+import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+
+class HmrcSectionCaptionSpec extends AnyWordSpec with Matchers {
+
+  lazy val messagesApi: MessagesApi =
+    stubMessagesApi(
+      Map(
+        "en" -> Map("this.section.is" -> "This section is"),
+        "cy" -> Map("this.section.is" -> "This section is (welsh)")
+      ),
+      new DefaultLangs(Seq(Lang("en"), Lang("cy")))
+    )
+
+  implicit val englishMessages = messagesApi.preferred(Seq(Lang("en")))
+  val welshMessages            = messagesApi.preferred(Seq(Lang("cy")))
+
+  "HmrcSectionCaption" must {
+    "construct caption with a visually hidden prefix" in {
+      HmrcSectionCaption(Text("Personal details")) mustBe HtmlContent(
+        """<span class="govuk-visually-hidden">This section is </span>Personal details"""
+      )
+    }
+
+    "require section to be non empty" in {
+      try {
+        HmrcSectionCaption(Text(""))
+        fail("construction succeeded with empty text")
+      } catch {
+        case e: IllegalArgumentException => // pass
+      }
+    }
+
+    "allow default content to be translated via messages" in {
+      HmrcSectionCaption(Text("Personal details"))(welshMessages) mustBe HtmlContent(
+        """<span class="govuk-visually-hidden">This section is (welsh) </span>Personal details"""
+      )
+    }
+  }
+}


### PR DESCRIPTION
Helpers have been added for constructing page heading labels and legends **_that include a section_** without having to create the html yourself.

Builds on https://github.com/hmrc/play-frontend-hmrc/pull/106/files