### PR TITLE
PLATUI-1365: update hmrc-frontend to 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 For compatibility information see `govukFrontendVersion` and `hmrcFrontendVersion` in
 [LibDependencies](project/LibDependencies.scala)
 
+## [1.19.0] - 2021-10-07
+
+### Fixed
+
+- Updated version of hmrc-frontend to 2.7.0 which has a fix for timeout dialog navigation issues for screen readers
+
+### Compatible with
+
+- [hmrc/hmrc-frontend v2.7.0](https://github.com/hmrc/hmrc-frontend/releases/tag/v2.7.0)
+- [alphagov/govuk-frontend v3.13.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.13.0)
+
 ## [1.18.0] - 2021-10-07
 
 ### Fixed

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -6,7 +6,7 @@ import sbt.ModuleID
 
 object LibDependencies {
   val govukFrontendVersion: String     = "3.13.0"
-  val hmrcFrontendVersion: String      = "2.6.0"
+  val hmrcFrontendVersion: String      = "2.7.0"
   val playFrontendGovukVersion: String = "2.0.0"
   val playLanguageVersion: String      = "5.0.0"
 


### PR DESCRIPTION
Follows from https://github.com/hmrc/hmrc-frontend/pull/187

(and fixes some changelog version urls that I messed up in a previous change!)