### PR TITLE
Allow ovverriding page layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 For compatibility information see `govukFrontendVersion` and `hmrcFrontendVersion` in
 [LibDependencies](project/LibDependencies.scala)
 
+## [1.24.0] - 2021-11-05
+
+### Updated
+
+- Added page layout argument to layout components, to allow internal services to use a full width layout.
+
+### Compatible with
+
+- [hmrc/hmrc-frontend v3.0.0](https://github.com/hmrc/hmrc-frontend/releases/tag/v3.0.0)
+- [alphagov/govuk-frontend v3.13.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.13.0)
+
 ## [1.23.0] - 2021-11-05
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -374,28 +374,34 @@ To use this component,
     )(contentBlock)
     ```
 
-1. The parameters that can be passed into the `hmrcLayout` and their default values are as follows:
+   1. The parameters that can be passed into the `hmrcLayout` and their default values are as follows:
 
-   | Parameter                     | Description                                                       | Example                                                   |
-   | ----------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------- |
-   | `pageTitle`                   | This will be bound to govukLayout                                 |                                                           |
-   | `isWelshTranslationAvailable` | Setting to true will display the language toggle                  | true                                                      |
-   | `serviceUrl`                  | This will be bound to hmrcStandardHeader                          | Some(routes.IndexController.index().url)                  |
-   | `signOutUrl`                  | Passing a value will display the sign out link                    | Some(routes.SignOutController.signOut().url)              |
-   | `userResearchBannerUrl`       | Passing a value will display the user research banner             | Some(UserResearchBanner(url = appConfig.userResearchUrl)) |
-   | `accessibilityStatementUrl`   | Passing a value will override the accessibility statement URL in the [footer](#accessibility-statement-links)                 ||
-   | `backLinkUrl`                 | Passing a value will display a back link                          | Some(routes.ServiceController.start().url)                |
-   | `displayHmrcBanner`           | Setting to true will display the [HMRC banner](https://design.tax.service.gov.uk/hmrc-design-patterns/hmrc-banner/)          ||
-   | `phaseBanner`                 | Passing a value will display alpha or beta banner.                | Some(standardBetaBanner(url = appConfig.betaFeedbackUrl)) |
-   | `additionalHeadBlock`         | Passing a value will add additional content in the HEAD element   |                                                           |
-   | `additionalScriptsBlock`      | Passing a value will add additional scripts at the end of the BODY|                                                           |
-   | `beforeContentBlock`          | Passing a value will add content between the header and the main element. This content will override any `isWelshTranslationAvailable` or `backLinkUrl` parameter.||
-   | `nonce`                       | This will be bound to hmrcHead, hmrcScripts and govukTemplate     |                                                           |
-   | `mainContentLayout`           | Passing value will override the default two thirds layout         |                                                           |
-   | `serviceName`                 | Pass a value only if your service has a dynamic service name      |                                                           |
-   | `additionalBannersBlock`      | Pass extra html into the header, intended for custom banners.     | Some(attorneyBanner)                                      |
+      | Parameter                     | Description                                                       | Example                                                   |
+      | ----------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------- |
+      | `pageTitle`                   | This will be bound to govukLayout                                 |                                                           |
+      | `isWelshTranslationAvailable` | Setting to true will display the language toggle                  | true                                                      |
+      | `serviceUrl`                  | This will be bound to hmrcStandardHeader                          | Some(routes.IndexController.index().url)                  |
+      | `signOutUrl`                  | Passing a value will display the sign out link                    | Some(routes.SignOutController.signOut().url)              |
+      | `userResearchBannerUrl`       | Passing a value will display the user research banner             | Some(UserResearchBanner(url = appConfig.userResearchUrl)) |
+      | `accessibilityStatementUrl`   | Passing a value will override the accessibility statement URL in the [footer](#accessibility-statement-links)                 ||
+      | `backLinkUrl`                 | Passing a value will display a back link                          | Some(routes.ServiceController.start().url)                |
+      | `displayHmrcBanner`           | Setting to true will display the [HMRC banner](https://design.tax.service.gov.uk/hmrc-design-patterns/hmrc-banner/)          ||
+      | `phaseBanner`                 | Passing a value will display alpha or beta banner.                | Some(standardBetaBanner(url = appConfig.betaFeedbackUrl)) |
+      | `additionalHeadBlock`         | Passing a value will add additional content in the HEAD element   |                                                           |
+      | `additionalScriptsBlock`      | Passing a value will add additional scripts at the end of the BODY|                                                           |
+      | `beforeContentBlock`          | Passing a value will add content between the header and the main element. This content will override any `isWelshTranslationAvailable` or `backLinkUrl` parameter.||
+      | `nonce`                       | This will be bound to hmrcHead, hmrcScripts and govukTemplate     |                                                           |
+      | `mainContentLayout`           | Passing value will override the default two thirds layout         |                                                           |
+      | `serviceName`                 | Pass a value only if your service has a dynamic service name      |                                                           |
+      | `additionalBannersBlock`      | Pass extra html into the header, intended for custom banners.     | Some(attorneyBanner)                                      |
+      | `pageLayout`                  | Allow internal services to use a full width layout.               | Some(fixedWidthPageLayout(_))                             |
+      | `headerContainerClasses`      | Allow internal services to use a full width header.               | "govuk-width-container"                                   |
 
-#### HmrcPageHeadingLabel and HmrcPageHeadingLegend
+### FullWidthPageLayout should only be used by internal services
+
+The default fixed width layout is for public services.
+
+## HmrcPageHeadingLabel and HmrcPageHeadingLegend
 
 These helpers let you use a label or legend as a page heading with a section (caption) displayed above it.
 

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/views/Aliases.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/views/Aliases.scala
@@ -195,6 +195,9 @@ trait Aliases {
 
   type CookieBanner = viewmodels.cookiebanner.CookieBanner
   val CookieBanner = viewmodels.cookiebanner.CookieBanner
+
+  type PageLayout = viewmodels.pagelayout.PageLayout
+  val PageLayout = viewmodels.pagelayout.PageLayout
 }
 
 object Aliases extends Aliases

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/pagelayout/PageLayout.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/pagelayout/PageLayout.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.govukfrontend.views.viewmodels.pagelayout
+
+import play.twirl.api.Html
+
+case class PageLayout(
+  beforeContentBlock: Option[Html],
+  contentBlock: Html,
+  mainLang: Option[String],
+  mainClasses: Option[String]
+)

--- a/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/FixedWidthPageLayout.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/FixedWidthPageLayout.scala.html
@@ -1,0 +1,30 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.pagelayout.PageLayout
+
+@this()
+
+@(params: PageLayout)
+
+@import params._
+
+<div class="govuk-width-container ">
+    @beforeContentBlock
+    <main class="govuk-main-wrapper @mainClasses" id="main-content" role="main"@mainLang.filter(_.nonEmpty).map {mainLang => lang="@mainLang"}>
+        @contentBlock
+    </main>
+</div>

--- a/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/FullWidthPageLayout.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/FullWidthPageLayout.scala.html
@@ -1,0 +1,30 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.pagelayout.PageLayout
+
+@this()
+
+@(params: PageLayout)
+
+@import params._
+
+<div class="govuk-width-container ">
+    @beforeContentBlock
+</div>
+<main class="govuk-main-wrapper @mainClasses" id="main-content" role="main"@mainLang.filter(_.nonEmpty).map {mainLang => lang="@mainLang"}>
+    @contentBlock
+</main>

--- a/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/GovukLayout.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/GovukLayout.scala.html
@@ -15,13 +15,15 @@
  *@
 
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.pagelayout.PageLayout
 
 @this(
   govukTemplate: GovukTemplate,
   govukHeader: GovukHeader,
   govukFooter: GovukFooter,
   govukBackLink: GovukBackLink,
-  defaultMainContentLayout: TwoThirdsMainContent
+  defaultMainContentLayout: TwoThirdsMainContent,
+  fixedWidthPageLayout: FixedWidthPageLayout
 )
 
 @(
@@ -35,7 +37,8 @@
   scriptsBlock: Option[Html] = None,
   mainContentLayout: Option[Html => Html] = Some(defaultMainContentLayout(_)),
   assetPath: Option[String] = None,
-  cspNonce: Option[String] = None
+  cspNonce: Option[String] = None,
+  pageLayout: Option[PageLayout => Html] = Some(fixedWidthPageLayout(_))
 )(contentBlock: Html)(implicit messages: Messages)
 
 @headerDefault = {
@@ -73,5 +76,6 @@
   mainClasses = Some("govuk-main-wrapper--auto-spacing"),
   bodyEndBlock = Some(bodyEndDefault),
   assetPath = assetPath,
-  cspNonce = cspNonce
+  cspNonce = cspNonce,
+  pageLayout = pageLayout
 )(mainContent)

--- a/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/GovukTemplate.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/GovukTemplate.scala.html
@@ -15,8 +15,15 @@
  *@
 
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.pagelayout.PageLayout
 
-@this(govukHeader: GovukHeader, govukFooter: GovukFooter, govukSkipLink: GovukSkipLink)
+@this(
+    govukHeader: GovukHeader,
+    govukFooter: GovukFooter,
+    govukSkipLink: GovukSkipLink,
+    fixedWidthPageLayout: FixedWidthPageLayout
+)
+
 
 @(
   htmlLang: Option[String] = None,
@@ -36,7 +43,8 @@
   mainClasses: Option[String] = None,
   beforeContentBlock: Option[Html] = None,
   assetPath: Option[String] = None,
-  cspNonce: Option[String] = None
+  cspNonce: Option[String] = None,
+  pageLayout: Option[PageLayout => Html] = Some(fixedWidthPageLayout(_))
 )(contentBlock: Html)<!DOCTYPE html>
 <html lang="@htmlLang.getOrElse {en}" class="govuk-template @htmlClasses">
   <head>
@@ -78,12 +86,7 @@
 
     @headerBlock
 
-    <div class="govuk-width-container ">
-      @beforeContentBlock
-      <main class="govuk-main-wrapper @mainClasses" id="main-content" role="main"@mainLang.filter(_.nonEmpty).map {mainLang => lang="@mainLang"}>
-        @contentBlock
-      </main>
-    </div>
+    @pageLayout.map(_(PageLayout(beforeContentBlock, contentBlock, mainLang, mainClasses))).getOrElse(contentBlock)
 
     @footerBlock
 

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcLayout.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcLayout.scala.html
@@ -26,6 +26,9 @@
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.backlink.BackLink
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.phasebanner.PhaseBanner
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.pagelayout.PageLayout
+@import uk.gov.hmrc.govukfrontend.views.html.components.FixedWidthPageLayout
+@import uk.gov.hmrc.hmrcfrontend.views.Aliases.Header
 
 @this(
         govukLayout: GovukLayout,
@@ -35,7 +38,8 @@
         hmrcLanguageSelectHelper: HmrcLanguageSelectHelper,
         hmrcScripts: HmrcScripts,
         govukBackLink: GovukBackLink,
-        defaultMainContent: TwoThirdsMainContent
+        defaultMainContent: TwoThirdsMainContent,
+        fixedWidthPageLayout: FixedWidthPageLayout
 )
 
 @(
@@ -54,7 +58,9 @@
         beforeContentBlock: Option[Html] = None,
         nonce: Option[String] = None,
         mainContentLayout: Option[Html => Html] = Some(defaultMainContent(_)),
-        additionalBannersBlock: Option[Html] = None
+        additionalBannersBlock: Option[Html] = None,
+        pageLayout: Option[PageLayout => Html] = Some(fixedWidthPageLayout(_)),
+        headerContainerClasses: String = Header.defaultObject.containerClasses
 )(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
 
 @headerBlock = {
@@ -65,7 +71,8 @@
         userResearchBanner = userResearchBannerUrl.map(url => UserResearchBanner(url = url)),
         phaseBanner = phaseBanner,
         displayHmrcBanner = displayHmrcBanner,
-        additionalBannersBlock = additionalBannersBlock
+        additionalBannersBlock = additionalBannersBlock,
+        containerClasses = headerContainerClasses
     )
 }
 
@@ -91,5 +98,6 @@
     footerBlock = Some(hmrcStandardFooter(accessibilityStatementUrl = accessibilityStatementUrl)),
     mainContentLayout = mainContentLayout,
     assetPath = None,
-    cspNonce = nonce
+    cspNonce = nonce,
+    pageLayout = pageLayout
 )(contentBlock)

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcStandardHeader.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcStandardHeader.scala.html
@@ -27,7 +27,8 @@
   userResearchBanner: Option[UserResearchBanner] = None,
   phaseBanner: Option[PhaseBanner] = None,
   displayHmrcBanner: Boolean = false,
-  additionalBannersBlock: Option[Html] = None
+  additionalBannersBlock: Option[Html] = None,
+  containerClasses: String = Header.defaultObject.containerClasses
 )(implicit messages: Messages, request: RequestHeader)
 @defining("service.name") { serviceNameKey =>
   @defining(if(messages.isDefinedAt(serviceNameKey)) Some(messages(serviceNameKey)) else None) { serviceNameFromMessages =>
@@ -41,7 +42,8 @@
       userResearchBanner = userResearchBanner,
       phaseBanner = phaseBanner,
       displayHmrcBanner = displayHmrcBanner,
-      additionalBannersBlock = additionalBannersBlock
+      additionalBannersBlock = additionalBannersBlock,
+      containerClasses = containerClasses
     ))
   }
 }

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/views/components/FixedWidthPageLayoutSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/views/components/FixedWidthPageLayoutSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.govukfrontend.views.components
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.twirl.api.Html
+import uk.gov.hmrc.govukfrontend.views.Aliases.PageLayout
+import uk.gov.hmrc.govukfrontend.views.html.components.FixedWidthPageLayout
+
+class FixedWidthPageLayoutSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
+
+  private val component = app.injector.instanceOf[FixedWidthPageLayout]
+
+  "Given a PageLayout render it at fixed width" should {
+    "render as expected" in {
+      component(
+        PageLayout(
+          Some(Html("beforeContentBlock")),
+          contentBlock = Html("contentBlock"),
+          mainLang = Some("en"),
+          mainClasses = Some("custom-class")
+        )
+      ) shouldBe Html(
+        s"""
+           |
+           |<div class="govuk-width-container ">
+           |    beforeContentBlock
+           |    <main class="govuk-main-wrapper custom-class" id="main-content" role="main" lang="en">
+           |        contentBlock
+           |    </main>
+           |</div>""".stripMargin
+      )
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/views/components/FullWidthPageLayoutSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/views/components/FullWidthPageLayoutSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.govukfrontend.views.components
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.twirl.api.Html
+import uk.gov.hmrc.govukfrontend.views.Aliases.PageLayout
+import uk.gov.hmrc.govukfrontend.views.html.components.FullWidthPageLayout
+
+class FullWidthPageLayoutSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
+
+  private val component = app.injector.instanceOf[FullWidthPageLayout]
+
+  "Given a PageLayout render it at full width" should {
+    "render as expected" in {
+      component(
+        PageLayout(
+          Some(Html("beforeContentBlock")),
+          contentBlock = Html("contentBlock"),
+          mainLang = Some("en"),
+          mainClasses = Some("custom-class")
+        )
+      ) shouldBe Html(
+        s"""
+           |
+           |<div class="govuk-width-container ">
+           |    beforeContentBlock
+           |</div>
+           |<main class="govuk-main-wrapper custom-class" id="main-content" role="main" lang="en">
+           |    contentBlock
+           |</main>""".stripMargin
+      )
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/helpers/hmrcLayoutSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/helpers/hmrcLayoutSpec.scala
@@ -29,7 +29,7 @@ import play.api.mvc.MessagesRequest
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsString, stubMessagesApi, _}
 import play.twirl.api.Html
-import uk.gov.hmrc.govukfrontend.views.html.components.GovukBackLink
+import uk.gov.hmrc.govukfrontend.views.html.components.{FullWidthPageLayout, GovukBackLink}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.backlink.BackLink
 import uk.gov.hmrc.helpers.views.JsoupHelpers
 import uk.gov.hmrc.hmrcfrontend.config.AssetsConfig
@@ -436,6 +436,24 @@ class hmrcLayoutSpec extends AnyWordSpecLike with Matchers with JsoupHelpers wit
       backLink                should have size 1
       backLink.attr("href") shouldBe "my-back-link"
       backLink.html()       shouldBe "Back Welsh"
+    }
+
+    "allow overriding of the default page layout" in {
+      val hmrcLayout          = app.injector.instanceOf[HmrcLayout]
+      val fullWidthPageLayout = app.injector.instanceOf[FullWidthPageLayout]
+      val messages            = getMessages(Lang("en"))
+      val layout              = hmrcLayout(
+        pageLayout = Some(fullWidthPageLayout(_)),
+        beforeContentBlock = Some(Html("beforeContentBlock")),
+        mainContentLayout = None
+      )(Html("contentBlock"))(fakeRequest, messages)
+
+      val document = Jsoup.parse(contentAsString(layout))
+      document.select("body > .govuk-width-container > main") should have size 0
+      document.html()                                         should include("beforeContentBlock")
+      val mainElement = document.select("body > main")
+      mainElement          should have size 1
+      mainElement.html() shouldBe "contentBlock"
     }
   }
 }


### PR DESCRIPTION
We have extracted the default fixed width layout and added a way to override the page layout in HmrcLayout, GovukLayout and GovukTemplate.

We have exposed a way to make the header full width via the headerContainerClasses argument in HmrcLayout and HmrcStandardHeader.