### PR TITLE
Update integration guidance for timeout dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For compatibility information see `govukFrontendVersion` and `hmrcFrontendVersio
 
 ### Changed
 
-- Tried to improve integration guidance for hmrc timeout dialog in README around use of signOutUrl
+- Updated integration guidance for hmrc timeout dialog in README around use of signOutUrl
 
 ### Compatible with
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 For compatibility information see `govukFrontendVersion` and `hmrcFrontendVersion` in
 [LibDependencies](project/LibDependencies.scala)
 
+## [3.5.0] - 2022-02-28
+
+### Changed
+
+- Tried to improve integration guidance for hmrc timeout dialog in README around use of signOutUrl
+
+### Compatible with
+
+- [hmrc/hmrc-frontend v4.5.0](https://github.com/hmrc/hmrc-frontend/releases/tag/v4.5.0)
+- [alphagov/govuk-frontend v4.0.1](https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.1)
+
 ## [3.4.0] - 2022-02-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -688,9 +688,10 @@ returning them to the supplied `signOutUrl`.
 
 The instructions below assume you have set up play-frontend-hmrc as indicated above.
 
-1. Identify the `signOutUrl` that will be used when users click 'Sign Out' on the timeout dialog. A sensible choice for this is the
-   url that is already supplied as the `signOutUrl` parameter to the `hmrcStandardHeader` component, which controls the sign
-   out link in the GOV.UK header. See related guidance above.
+1. Identify the `signOutUrl` that should be used when users click 'Sign Out' on the timeout dialog. Your service may already be 
+   supplying a `signOutUrl` parameter to the `hmrcStandardHeader` component, which controls the sign out link in the GOV.UK 
+   header. Reusing this value may be a sensible choice. Refer to guidance above to understand how this argument is used by the 
+   timeout dialog.
 
 1. Update your layout template to pass in the `hmrcTimeoutDialogHelper` in the HEAD element, supplying the signOutUrl as
    a parameter. For example if using `hmrcLayout`, pass `Some(hmrcTimeoutDialogHelper(signOutUrl = signOutUrl))` in the 


### PR DESCRIPTION
Couldn't find any definitive / linkable guidance around using the sign out routes provided by bas-gateway. So have not added any information about general sign out behaviour on platform. However I've tried to adjust the language so it's clearer we're not providing any suitable default value from the library itself. But that there might be a value in use already by the service that a developer can probably reuse.