### PR TITLE
PLATUI-1690 remove trailing space from HmrcNewTabLink/HmrcNewTabLinkHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 For compatibility information see `govukFrontendVersion` and `hmrcFrontendVersion` in
 [LibDependencies](project/LibDependencies.scala)
 
+## [3.14.0] - 2022-04-12
+
+### Fixed
+
+- Removed trailing spaces from `HmrcNewTabLink`/`HmrcNewTabLinkHelper`, so that consuming services can embed these in surrounding content without having to trim.
+
+### Compatible with
+
+- [hmrc/hmrc-frontend v5.0.3](https://github.com/hmrc/hmrc-frontend/releases/tag/v5.0.3)
+- [alphagov/govuk-frontend v4.0.1](https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.1)
+
 ## [3.13.0] - 2022-04-07
 
 ### Fixed

--- a/src/it/scala/uk/gov/hmrc/hmrcfrontend/views/components/HmrcAddToAListIntegrationSpec.scala
+++ b/src/it/scala/uk/gov/hmrc/hmrcfrontend/views/components/HmrcAddToAListIntegrationSpec.scala
@@ -11,7 +11,7 @@ import uk.gov.hmrc.support.TemplateIntegrationBaseSpec
 
 import scala.util.Try
 
-object HmrcAddToAListSpec
+object HmrcAddToAListIntegrationSpec
     extends TemplateIntegrationBaseSpec[AddToAList](
       componentName = "hmrcAddToAList",
       seed = None

--- a/src/it/scala/uk/gov/hmrc/hmrcfrontend/views/components/HmrcTimelineIntegrationSpec.scala
+++ b/src/it/scala/uk/gov/hmrc/hmrcfrontend/views/components/HmrcTimelineIntegrationSpec.scala
@@ -5,6 +5,6 @@ import uk.gov.hmrc.hmrcfrontend.support.TemplateIntegrationSpec
 import uk.gov.hmrc.hmrcfrontend.views.html.components._
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.timeline.Generators._
 
-object HmrcTimelineSpec
+object HmrcTimelineIntegrationSpec
     extends TemplateIntegrationSpec[Timeline, HmrcTimeline](hmrcComponentName = "hmrcTimeline", seed = None)
     with MessagesSupport

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/components/HmrcNewTabLink.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/components/HmrcNewTabLink.scala.html
@@ -17,12 +17,11 @@
 @this()
 
 @(params: NewTabLink)
-@import params._
+@import params.{language => lang, _}
 
-@if(!text.isEmpty) {
- <a class="@toClasses("govuk-link ", classList.getOrElse(""))" target="_blank" rel="noopener noreferrer" href="@href">@text@params.language match {
-   case Some("en") => { (opens in a new tab)</a>}
-   case Some("cy") => { (yn agor tab newydd)</a>}
-   case _ => {</a>}
- }
-}
+@if(text.nonEmpty) {
+ <a class="@toClasses("govuk-link ", classList.getOrElse(""))" target="_blank" rel="noopener noreferrer" href="@href">@text@lang match {
+   case Some("en") => { (opens in a new tab)}
+   case Some("cy") => { (yn agor tab newydd)}
+   case _ => {}
+ }</a>}

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcNewTabLinkHelper.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcNewTabLinkHelper.scala.html
@@ -27,4 +27,3 @@
  language = Some(messages.lang.language),
  classList = newTabLinkHelper.classList
 ))
-

--- a/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/helpers/hmrcNewTabLinkHelperSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/helpers/hmrcNewTabLinkHelperSpec.scala
@@ -131,5 +131,13 @@ class hmrcNewTabLinkHelperSpec extends AnyWordSpecLike with Matchers with Messag
       links.first.attr("target") shouldBe "_blank"
       links.text()               shouldBe "Ciao raggazzi"
     }
+
+    "render link without trailing space, so that it can be included in some outer element without trimming" in {
+      val newTabLinkHelper     = NewTabLinkHelper(text = "Some link text")
+      val hmrcNewTabLinkHelper = new HmrcNewTabLinkHelper(new HmrcNewTabLink())
+      val component            = hmrcNewTabLinkHelper(newTabLinkHelper)(englishMessages)
+
+      component.toString should endWith(">Some link text (opens in a new tab)</a>")
+    }
   }
 }


### PR DESCRIPTION
I was thinking of extracting the newTabLink into a Scala helper to make it less ugly and prone to regression, but there's no existing pattern for doing that in this repo, and these components pretty much mirror those in [hmrc-frontend](https://github.com/hmrc/hmrc-frontend/blob/main/src/components/new-tab-link/template.njk), so it's probably better to leave it as-is.

I've added a test to ensure the HmrcNewTabLinkHelper component has no trailing space, to guard against any future regression.