### PR TITLE
PLATUI-1722: update play-language to 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 For compatibility information see `govukFrontendVersion` and `hmrcFrontendVersion` in
 [LibDependencies](project/LibDependencies.scala)
 
+## [3.17.0] - 2022-05-12
+
+### Changed
+
+- Updated play-language to 5.3.0
+
+### Compatible with
+
+- [hmrc/hmrc-frontend v5.0.4](https://github.com/hmrc/hmrc-frontend/releases/tag/v5.0.4)
+- [alphagov/govuk-frontend v4.0.1](https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.1)
+
 ## [3.16.0] - 2022-05-10
 
 ### Changed

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -7,7 +7,7 @@ import sbt.ModuleID
 object LibDependencies {
   val govukFrontendVersion: String = "4.0.1"
   val hmrcFrontendVersion: String  = "5.0.4"
-  val playLanguageVersion: String  = "5.2.0"
+  val playLanguageVersion: String  = "5.3.0"
 
   val compile: Seq[ModuleID] = dependencies(
     shared = Seq(


### PR DESCRIPTION
To get [fix for url encoding issue](https://github.com/hmrc/play-language/pull/43)