### PR TITLE
PLATUI-2010 create new HmrcStandardLayout to supersede HmrcLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 For compatibility information see `govukFrontendVersion` and `hmrcFrontendVersion` in
 [LibDependencies](project/LibDependencies.scala)
 
+## [6.3.0] - 2023-01-23
+
+### Changed
+
+- Deprecated `HmrcLayout` template; added new `HmrcStandardPage` template to replace it. 
+
+### Compatible with
+
+- [hmrc/hmrc-frontend v5.19.0](https://github.com/hmrc/hmrc-frontend/releases/tag/v5.19.0)
+- [alphagov/govuk-frontend v4.4.1](https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.1)
+
+
 ## [6.2.0] - 2023-01-12
 
 ### Changed

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ sys.env.getOrElse("PLAY_VERSION", "2.8") match {
     ).map(addSbtPlugin)
 }
 
-addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build"             % "3.8.0")
+addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build"             % "3.9.0")
 addSbtPlugin("uk.gov.hmrc"   % "sbt-play-cross-compilation" % "2.3.0")
 addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo"              % "0.7.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"               % "2.4.0")

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/backlink/BackLink.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/views/viewmodels/backlink/BackLink.scala
@@ -33,9 +33,17 @@ object BackLink {
 
   def defaultObject: BackLink = BackLink()
 
-  def mimicsBrowserBackButtonViaJavaScript(implicit messages: Messages): BackLink = BackLink(
+  def mimicsBrowserBackButtonViaJavaScript(implicit messages: Messages): BackLink = BackLink.withDefaultText(
     href = "#",
-    attributes = Map("data-module" -> "hmrc-back-link"),
+    attributes = Map("data-module" -> "hmrc-back-link")
+  )
+
+  def withDefaultText(href: String, classes: String = "", attributes: Map[String, String] = Map.empty)(implicit
+    messages: Messages
+  ): BackLink = BackLink(
+    href = href,
+    classes = classes,
+    attributes = attributes,
     content = Text(messages("back.text"))
   )
 

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/Banners.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/Banners.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage
+
+import play.twirl.api.Html
+import uk.gov.hmrc.govukfrontend.views.Aliases.PhaseBanner
+import uk.gov.hmrc.hmrcfrontend.views.Aliases.UserResearchBanner
+
+case class Banners(
+  displayHmrcBanner: Boolean = false,
+  phaseBanner: Option[PhaseBanner] = None,
+  userResearchBanner: Option[UserResearchBanner] = None,
+  additionalBannersBlock: Option[Html] = None
+)

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/HmrcStandardPageParams.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/HmrcStandardPageParams.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage
+
+import uk.gov.hmrc.govukfrontend.views.Aliases.BackLink
+
+case class HmrcStandardPageParams(
+  serviceURLs: ServiceURLs = ServiceURLs(),
+  banners: Banners = Banners(),
+  templateOverrides: TemplateOverrides = TemplateOverrides(),
+  serviceName: Option[String] = None,
+  isWelshTranslationAvailable: Boolean = false,
+  pageTitle: Option[String] = None,
+  backLink: Option[BackLink] = None,
+  cspNonce: Option[String] = None
+)

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/ServiceURLs.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/ServiceURLs.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage
+
+case class ServiceURLs(
+  serviceUrl: Option[String] = None,
+  signOutUrl: Option[String] = None,
+  accessibilityStatementUrl: Option[String] = None
+)

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/TemplateOverrides.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/TemplateOverrides.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage
+
+import play.twirl.api.Html
+import uk.gov.hmrc.govukfrontend.views.Aliases.PageLayout
+import uk.gov.hmrc.hmrcfrontend.views.Aliases.Header
+
+case class TemplateOverrides(
+  additionalHeadBlock: Option[Html] = None,
+  additionalScriptsBlock: Option[Html] = None,
+  beforeContentBlock: Option[Html] = None,
+  mainContentLayout: Option[Html => Html] = None,
+  pageLayout: Option[PageLayout => Html] = None,
+  headerContainerClasses: String = Header.defaultObject.containerClasses
+)
+
+object TemplateOverrides {
+  val noMainContentLayout: Html => Html = identity
+}

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcLayout.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcLayout.scala.html
@@ -14,14 +14,8 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukBackLink
 @import uk.gov.hmrc.govukfrontend.views.html.components.TwoThirdsMainContent
-@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardHeader
-@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardFooter
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardPage
-@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcHead
-@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcLanguageSelectHelper
-@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcScripts
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.userresearchbanner.UserResearchBanner
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.backlink.BackLink
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.phasebanner.PhaseBanner
@@ -32,12 +26,6 @@
 
 @this(
         hmrcStandardPage: HmrcStandardPage,
-        hmrcStandardHeader: HmrcStandardHeader,
-        hmrcStandardFooter: HmrcStandardFooter,
-        hmrcHead: HmrcHead,
-        hmrcLanguageSelectHelper: HmrcLanguageSelectHelper,
-        hmrcScripts: HmrcScripts,
-        govukBackLink: GovukBackLink,
         defaultMainContent: TwoThirdsMainContent,
         fixedWidthPageLayout: FixedWidthPageLayout
 )

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcLayout.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcLayout.scala.html
@@ -14,24 +14,24 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukLayout
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukBackLink
 @import uk.gov.hmrc.govukfrontend.views.html.components.TwoThirdsMainContent
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardHeader
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardFooter
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardPage
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcHead
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcLanguageSelectHelper
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcScripts
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.userresearchbanner.UserResearchBanner
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.backlink.BackLink
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.phasebanner.PhaseBanner
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.pagelayout.PageLayout
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage._
 @import uk.gov.hmrc.govukfrontend.views.html.components.FixedWidthPageLayout
 @import uk.gov.hmrc.hmrcfrontend.views.Aliases.Header
 
 @this(
-        govukLayout: GovukLayout,
+        hmrcStandardPage: HmrcStandardPage,
         hmrcStandardHeader: HmrcStandardHeader,
         hmrcStandardFooter: HmrcStandardFooter,
         hmrcHead: HmrcHead,
@@ -62,44 +62,35 @@
         pageLayout: Option[PageLayout => Html] = Some(fixedWidthPageLayout(_)),
         headerContainerClasses: String = Header.defaultObject.containerClasses,
         backLink: Option[BackLink] = None
-)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
+)(@deprecated("HmrcLayout is deprecated, use HmrcStandardPage instead", "6.3.0") contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
 
 @require(!(backLinkUrl.isDefined && backLink.isDefined), "Use backLink or backLinkUrl, but not both")
 
-@headerBlock = {
-    @hmrcStandardHeader(
-        serviceUrl = serviceUrl,
-        signOutUrl = signOutUrl,
-        serviceName = serviceName,
-        userResearchBanner = userResearchBannerUrl.map(url => UserResearchBanner(url = url)),
-        phaseBanner = phaseBanner,
-        displayHmrcBanner = displayHmrcBanner,
-        additionalBannersBlock = additionalBannersBlock,
-        containerClasses = headerContainerClasses
-    )
-}
-
-@beforeContent = {
-    @if(beforeContentBlock.isDefined) {
-        @beforeContentBlock
-    } else {
-        @if(isWelshTranslationAvailable) {
-            @hmrcLanguageSelectHelper()
-        }
-        @{(backLink orElse backLinkUrl.map(url => BackLink(href = url, content = Text(messages("back.text")))))
-            .map(link => govukBackLink(link))}
-    }
-}
-
-@govukLayout(
+@hmrcStandardPage(
+  HmrcStandardPageParams(
+    serviceURLs = ServiceURLs(
+      serviceUrl = serviceUrl,
+      signOutUrl = signOutUrl,
+      accessibilityStatementUrl = accessibilityStatementUrl
+    ),
+    banners = Banners(
+      displayHmrcBanner = displayHmrcBanner,
+      phaseBanner = phaseBanner,
+      userResearchBanner = userResearchBannerUrl.map(url => UserResearchBanner(url = url)),
+      additionalBannersBlock = additionalBannersBlock
+    ),
+    templateOverrides = TemplateOverrides(
+      additionalHeadBlock = additionalHeadBlock,
+      additionalScriptsBlock = additionalScriptsBlock,
+      beforeContentBlock = beforeContentBlock,
+      mainContentLayout = mainContentLayout,
+      pageLayout = pageLayout,
+      headerContainerClasses = headerContainerClasses
+    ),
+    serviceName = serviceName,
     pageTitle = pageTitle,
-    headBlock = Some(hmrcHead(nonce = nonce, headBlock = additionalHeadBlock)),
-    headerBlock = Some(headerBlock),
-    scriptsBlock = Some(hmrcScripts(nonce = nonce, scriptsBlock = additionalScriptsBlock)),
-    beforeContentBlock = Some(beforeContent),
-    footerBlock = Some(hmrcStandardFooter(accessibilityStatementUrl = accessibilityStatementUrl)),
-    mainContentLayout = mainContentLayout,
-    assetPath = None,
-    cspNonce = nonce,
-    pageLayout = pageLayout
+    isWelshTranslationAvailable = isWelshTranslationAvailable,
+    backLink = backLink orElse backLinkUrl.map(url => BackLink.withDefaultText(href = url)),
+    cspNonce = nonce
+  )
 )(contentBlock)

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcStandardPage.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcStandardPage.scala.html
@@ -1,0 +1,76 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukLayout
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukBackLink
+@import uk.gov.hmrc.govukfrontend.views.html.components.TwoThirdsMainContent
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardHeader
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardFooter
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcHead
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcLanguageSelectHelper
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcScripts
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage.HmrcStandardPageParams
+@import uk.gov.hmrc.govukfrontend.views.html.components.FixedWidthPageLayout
+
+@this(
+        govukLayout: GovukLayout,
+        hmrcStandardHeader: HmrcStandardHeader,
+        hmrcStandardFooter: HmrcStandardFooter,
+        hmrcHead: HmrcHead,
+        hmrcLanguageSelectHelper: HmrcLanguageSelectHelper,
+        hmrcScripts: HmrcScripts,
+        govukBackLink: GovukBackLink,
+        defaultMainContent: TwoThirdsMainContent,
+        fixedWidthPageLayout: FixedWidthPageLayout
+)
+
+@(params: HmrcStandardPageParams)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
+@import params._
+
+@headerBlock = {
+    @hmrcStandardHeader(
+        serviceUrl = serviceURLs.serviceUrl,
+        signOutUrl = serviceURLs.signOutUrl,
+        serviceName = serviceName,
+        userResearchBanner = banners.userResearchBanner,
+        phaseBanner = banners.phaseBanner,
+        displayHmrcBanner = banners.displayHmrcBanner,
+        additionalBannersBlock = banners.additionalBannersBlock,
+        containerClasses = templateOverrides.headerContainerClasses
+    )
+}
+
+@beforeContent = {
+    @if(isWelshTranslationAvailable) {
+        @hmrcLanguageSelectHelper()
+    }
+    @backLink.map { link =>
+      @govukBackLink(link)
+    }
+}
+
+@govukLayout(
+    pageTitle = pageTitle,
+    headBlock = Some(hmrcHead(nonce = cspNonce, headBlock = templateOverrides.additionalHeadBlock)),
+    headerBlock = Some(headerBlock),
+    scriptsBlock = Some(hmrcScripts(nonce = cspNonce, scriptsBlock = templateOverrides.additionalScriptsBlock)),
+    beforeContentBlock = templateOverrides.beforeContentBlock orElse Some(beforeContent),
+    footerBlock = Some(hmrcStandardFooter(accessibilityStatementUrl = serviceURLs.accessibilityStatementUrl)),
+    mainContentLayout = templateOverrides.mainContentLayout orElse Some(defaultMainContent(_)),
+    assetPath = None,
+    cspNonce = cspNonce,
+    pageLayout = templateOverrides.pageLayout orElse Some(fixedWidthPageLayout(_))
+)(contentBlock)


### PR DESCRIPTION
* create new `HmrcStandardPage` template that takes a single parameter `HmrcStandardPageParams`
* `HmrcStandardPageParams` encapsulates parameters from `HmrcLayout` template, grouped into logical entities:
  * `ServiceURLs` - service-specific URLs that can probably be set once
  * `Banners` - parameters relating to what banners to show on a page - probably set once but might be contextual
  * `TemplateOverrides` - parameters that override the default layout or inject additional HTML
  * `serviceName`, `pageTitle`, `isWelshTranslationAvailable`, `backLink` and `cspNonce` left at the top level - will be wired up in the service team's own `Layout` class
* Existing `HmrcLayout` now just wraps `HmrcStandardPage` - also provides a pattern for teams to easily migrate to the new template, if and when they need to
* new page params require typed `BackLink` and `UserResearchBanner` rather than URL strings
* TODO - how to mark old layout class as deprecated?