### PR TITLE
PLATUI 2394 layout spike

### DIFF
--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/TemplateOverrides.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/TemplateOverrides.scala
@@ -26,7 +26,6 @@ case class TemplateOverrides(
   beforeContentBlock: Option[Html] = None,
   mainContentLayout: Option[Html => Html] = None,
   pageLayout: Option[PageLayout => Html] = None,
-  isFullWidth: Boolean = false,
   headerContainerClasses: String = Header.defaultObject.containerClasses
 )
 

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/TemplateOverrides.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/hmrcstandardpage/TemplateOverrides.scala
@@ -26,6 +26,7 @@ case class TemplateOverrides(
   beforeContentBlock: Option[Html] = None,
   mainContentLayout: Option[Html => Html] = None,
   pageLayout: Option[PageLayout => Html] = None,
+  isFullWidth: Boolean = false,
   headerContainerClasses: String = Header.defaultObject.containerClasses
 )
 

--- a/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/FullWidthMainContent.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/FullWidthMainContent.scala.html
@@ -1,0 +1,25 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(contentBlock: Html)
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        @contentBlock
+    </div>
+</div>

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcStandardPage.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcStandardPage.scala.html
@@ -14,9 +14,11 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.govukfrontend.views.html.components.FullWidthMainContent
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukLayout
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukBackLink
 @import uk.gov.hmrc.govukfrontend.views.html.components.TwoThirdsMainContent
+@import uk.gov.hmrc.govukfrontend.views.html.components.TwoThirdsOneThirdMainContent
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardHeader
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardFooter
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcHead
@@ -35,11 +37,13 @@
         hmrcScripts: HmrcScripts,
         govukBackLink: GovukBackLink,
         govukExitThisPage: GovukExitThisPage,
-        defaultMainContent: TwoThirdsMainContent,
+        twoThirdsMainContent: TwoThirdsMainContent,
+        twoThirdsOneThirdMainContent: TwoThirdsOneThirdMainContent,
+        fullWidthMainContent: FullWidthMainContent,
         fixedWidthPageLayout: FixedWidthPageLayout
 )
 
-@(params: HmrcStandardPageParams)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
+@(params: HmrcStandardPageParams)(contentBlock: Html, sidebarContent: Option[Html] = None)(implicit request: RequestHeader, messages: Messages)
 @import params._
 
 @headerBlock = {
@@ -74,7 +78,16 @@
     scriptsBlock = Some(hmrcScripts(scriptsBlock = templateOverrides.additionalScriptsBlock)),
     beforeContentBlock = templateOverrides.beforeContentBlock orElse Some(beforeContent),
     footerBlock = Some(hmrcStandardFooter(accessibilityStatementUrl = serviceURLs.accessibilityStatementUrl)),
-    mainContentLayout = templateOverrides.mainContentLayout orElse Some(defaultMainContent(_)),
+    mainContentLayout = templateOverrides.mainContentLayout orElse
+        Some(sidebarContent match {
+            case Some(sidebarHtml) => twoThirdsOneThirdMainContent(sidebarHtml)(_)
+            case None =>
+                if(templateOverrides.isFullWidth) {
+                    fullWidthMainContent(_)
+                } else {
+                    twoThirdsMainContent(_)
+                }
+        }),
     assetPath = None,
     pageLayout = templateOverrides.pageLayout orElse Some(fixedWidthPageLayout(_))
 )(contentBlock)

--- a/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcStandardPage.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcStandardPage.scala.html
@@ -81,12 +81,7 @@
     mainContentLayout = templateOverrides.mainContentLayout orElse
         Some(sidebarContent match {
             case Some(sidebarHtml) => twoThirdsOneThirdMainContent(sidebarHtml)(_)
-            case None =>
-                if(templateOverrides.isFullWidth) {
-                    fullWidthMainContent(_)
-                } else {
-                    twoThirdsMainContent(_)
-                }
+            case None => twoThirdsMainContent(_)
         }),
     assetPath = None,
     pageLayout = templateOverrides.pageLayout orElse Some(fixedWidthPageLayout(_))


### PR DESCRIPTION
- PLATUI-2394 spike more ergonomic support for sidebar content / full-width layouts
- PLATUI-2394 teams requiring full-width could probably just pass fullWidthMainContent via templateOverrides.mainContentLayout
