### PR TITLE
PLATUI-2638 enable Welsh support in accessible-autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 For compatibility information see `govukFrontendVersion` and `hmrcFrontendVersion` in
 [LibDependencies](project/LibDependencies.scala)
 
+## [7.27.0] - 2023-11-09
+
+### Changed
+
+- Uplifted version of `hmrc-frontend` to `5.56.0`
+- Updated `RichSelectSupport`'s `asAccessibleAutocomplete` method to pull language from implicit `Messages`
+
+### Compatible with
+
+- [hmrc/hmrc-frontend v5.56.0](https://github.com/hmrc/hmrc-frontend/releases/tag/v5.56.0)
+- [alphagov/govuk-frontend v4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0)
+
 ## [7.26.0] - 2023-11-03
 
 ### Changed

--- a/docs/maintainers/adr/0019-add-welsh-language-support-to-govuk-accessible-autocomplete.md
+++ b/docs/maintainers/adr/0019-add-welsh-language-support-to-govuk-accessible-autocomplete.md
@@ -1,0 +1,49 @@
+# Add Welsh language support to the GOVUK accessible autocomplete wrapper
+
+* Status: accepted
+* Date: 2023-11-09
+
+Technical Story: PLATUI-2638
+
+## Context and Problem Statement
+
+In PLATUI-1830 we added an implicit HMRC helper to wire up a `select` element to the
+[GOVUK accessible-autocomplete](https://github.com/alphagov/accessible-autocomplete) component.
+This was intended as a minimal implementation, to prevent teams having to reimplement their own divergent solutions.
+It was later realised that, as with other GOVUK components, the accessible-autocomplete only provides content in English.
+Now that GOVUK have modified the component to expose an internationalisation API, we had the option to add Welsh translations.
+Translations have been provided by the accessible-autocomplete wrapper in hmrc-frontend, which now exposes a data-language attribute.
+
+## Decision Drivers
+
+* The need for services to consistently provide Welsh content, for compliance with the
+[WCAG Language of Parts](https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html) success criteria 
+* The need for components to justify their cost of maintenance
+
+## Considered Options
+
+* Do nothing, and leave service teams to provide the language parameter to the component
+* Add idiomatic Play language support to the HMRC accessible-autocomplete wrapper in this library
+
+## Decision Outcome
+
+Chosen option: "Add idiomatic Play language support to the HMRC accessible-autocomplete wrapper in this library",
+because we can easily do this in a way that is consistent with language support in other components,
+and doing so will reduce the work required from service teams.
+
+### Positive Consequences
+
+* The `asAccessibleAutocomplete` extension method in `RichSelect` will be language-aware via Play's `Messages`,
+so services can continue using the provided accessible-autocomplete component and get Welsh translations for free
+* Services will not fail DAC assessments due to missing Welsh translations, reducing the cost of re-engineering and re-testing
+
+### Negative Consequences
+
+* Using `asAccessibleAutocomplete` now requires a `Messages` object in implicit scope, which could be breaking,
+but in practice most views will already have a `Messages` object
+* Expectations may be set that we will update our accessible-autocomplete wrapper to support any future enhancements,
+which may or may not be the case
+
+## Links
+
+* Relates to [ADR-0016](0016-use-implicit-messages-to-drive-welsh-translations-in-govuk-twirl-components.md)

--- a/docs/maintainers/adr/index.md
+++ b/docs/maintainers/adr/index.md
@@ -20,6 +20,9 @@
 * [ADR-0016](0016-use-implicit-messages-to-drive-welsh-translations-in-govuk-twirl-components.md) - Use implicit messages to drive Welsh translations in GOVUK Twirl components
 * [ADR-0017](0017-add-timeout-dialog-hide-sign-out-button.md) - Add timeout-dialog hideSignOutButton
 * [ADR-0018](0018-help-teams-implement-new-date-guidance.md) - Help teams implement new date guidance
+* [ADR-0019](0019-add-welsh-language-support-to-govuk-accessible-autocomplete.md) - Add Welsh language support to the GOVUK accessible autocomplete wrapper
 
 <!-- adrlogstop -->
+
+
 

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -6,7 +6,7 @@ import sbt.ModuleID
 
 object LibDependencies {
   val govukFrontendVersion: String = "4.7.0"
-  val hmrcFrontendVersion: String  = "5.55.0"
+  val hmrcFrontendVersion: String  = "5.56.0"
   val playLanguageVersion: String  = "6.2.0"
 
   val compile: Seq[ModuleID] = dependencies(

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/views/implicits/RichSelectSupport.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/views/implicits/RichSelectSupport.scala
@@ -20,6 +20,7 @@ import play.api.data.Field
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Content
 import uk.gov.hmrc.govukfrontend.views.viewmodels.select.{Select, SelectItem}
+import uk.gov.hmrc.hmrcfrontend.views.Aliases.En
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.accessibleautocomplete.AccessibleAutocomplete
 
 trait RichSelectSupport {
@@ -62,7 +63,9 @@ trait RichSelectSupport {
     def withHeadingAndSectionCaption(heading: Content, sectionCaption: Content): Select =
       withHeadingLabel(select, heading, Some(sectionCaption))((sl, ul) => sl.copy(label = ul))
 
-    def asAccessibleAutocomplete(accessibleAutocomplete: Option[AccessibleAutocomplete] = None): Select = {
+    def asAccessibleAutocomplete(
+      accessibleAutocomplete: Option[AccessibleAutocomplete] = None
+    )(implicit messages: Messages): Select = {
       def toMapOfDataAttributes(accessibleAutocomplete: AccessibleAutocomplete): Map[String, String] =
         Map(
           "data-auto-select"     -> accessibleAutocomplete.autoSelect.toString,
@@ -74,7 +77,9 @@ trait RichSelectSupport {
       val dataAttributes =
         toMapOfDataAttributes(accessibleAutocomplete.getOrElse(AccessibleAutocomplete(None)))
 
-      select.copy(attributes = select.attributes ++ dataAttributes)
+      val maybeDataLanguage = Map("data-language" -> messages.lang.code).filterNot(_._2 == En.code)
+
+      select.copy(attributes = select.attributes ++ dataAttributes ++ maybeDataLanguage)
     }
 
     private[views] def withName(field: Field): Select =

--- a/src/main/scala/uk/gov/hmrc/govukfrontend/views/implicits/RichSelectSupport.scala
+++ b/src/main/scala/uk/gov/hmrc/govukfrontend/views/implicits/RichSelectSupport.scala
@@ -71,6 +71,7 @@ trait RichSelectSupport {
           "data-auto-select"     -> accessibleAutocomplete.autoSelect.toString,
           "data-show-all-values" -> accessibleAutocomplete.showAllValues.toString,
           "data-default-value"   -> accessibleAutocomplete.defaultValue.getOrElse(""),
+          "data-min-length"      -> accessibleAutocomplete.minLength.map(_.toString).getOrElse(""),
           "data-module"          -> accessibleAutocomplete.dataModule
         )
 

--- a/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/accessibleautocomplete/AccessibleAutocomplete.scala
+++ b/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/accessibleautocomplete/AccessibleAutocomplete.scala
@@ -16,13 +16,12 @@
 
 package uk.gov.hmrc.hmrcfrontend.views.viewmodels.accessibleautocomplete
 
-import play.api.libs.json.{Json, OFormat}
-
 case class AccessibleAutocomplete(
   defaultValue: Option[String] =
     None, // Please read on the usage of the defaultValue property at https://www.npmjs.com/package/accessible-autocomplete under the `Null options` heading
   showAllValues: Boolean = false,
-  autoSelect: Boolean = false
+  autoSelect: Boolean = false,
+  minLength: Option[Int] = None
 ) {
   val dataModule: String = "hmrc-accessible-autocomplete"
 }

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/views/implicits/RichSelectSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/views/implicits/RichSelectSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.govukfrontend.views.implicits
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import play.api.i18n.{Lang, Messages}
 import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.errormessage.ErrorMessage
@@ -180,6 +181,25 @@ class RichSelectSpec extends AnyWordSpec with Matchers with MessagesHelpers with
           "data-show-all-values" -> "true",
           "data-auto-select"     -> "true",
           "data-module"          -> "hmrc-accessible-autocomplete"
+        )
+      )
+    }
+
+    "set data-language when the current language is not English" in {
+      implicit val messages: Messages = messagesApi.preferred(Seq(Lang("cy")))
+
+      val select        = Select()
+      val updatedSelect = select.asAccessibleAutocomplete(
+        Some(AccessibleAutocomplete(Some("Test"), showAllValues = true, autoSelect = true))
+      )
+
+      updatedSelect shouldBe Select(attributes =
+        Map(
+          "data-default-value"   -> "Test",
+          "data-show-all-values" -> "true",
+          "data-auto-select"     -> "true",
+          "data-module"          -> "hmrc-accessible-autocomplete",
+          "data-language"        -> "cy"
         )
       )
     }

--- a/src/test/scala/uk/gov/hmrc/govukfrontend/views/implicits/RichSelectSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/govukfrontend/views/implicits/RichSelectSpec.scala
@@ -180,6 +180,7 @@ class RichSelectSpec extends AnyWordSpec with Matchers with MessagesHelpers with
           "data-default-value"   -> "Test",
           "data-show-all-values" -> "true",
           "data-auto-select"     -> "true",
+          "data-min-length"      -> "",
           "data-module"          -> "hmrc-accessible-autocomplete"
         )
       )
@@ -198,6 +199,34 @@ class RichSelectSpec extends AnyWordSpec with Matchers with MessagesHelpers with
           "data-default-value"   -> "Test",
           "data-show-all-values" -> "true",
           "data-auto-select"     -> "true",
+          "data-min-length"      -> "",
+          "data-module"          -> "hmrc-accessible-autocomplete",
+          "data-language"        -> "cy"
+        )
+      )
+    }
+
+    "set data-min-length when provided" in {
+      implicit val messages: Messages = messagesApi.preferred(Seq(Lang("cy")))
+
+      val select        = Select()
+      val updatedSelect = select.asAccessibleAutocomplete(
+        Some(
+          AccessibleAutocomplete(
+            Some("Test"),
+            showAllValues = true,
+            autoSelect = true,
+            minLength = Some(2)
+          )
+        )
+      )
+
+      updatedSelect shouldBe Select(attributes =
+        Map(
+          "data-default-value"   -> "Test",
+          "data-show-all-values" -> "true",
+          "data-auto-select"     -> "true",
+          "data-min-length"      -> "2",
           "data-module"          -> "hmrc-accessible-autocomplete",
           "data-language"        -> "cy"
         )
@@ -213,6 +242,7 @@ class RichSelectSpec extends AnyWordSpec with Matchers with MessagesHelpers with
           "data-default-value"   -> "",
           "data-show-all-values" -> "false",
           "data-auto-select"     -> "false",
+          "data-min-length"      -> "",
           "data-module"          -> "hmrc-accessible-autocomplete"
         )
       )
@@ -227,6 +257,7 @@ class RichSelectSpec extends AnyWordSpec with Matchers with MessagesHelpers with
           "data-default-value"   -> "Test",
           "data-show-all-values" -> "false",
           "data-auto-select"     -> "false",
+          "data-min-length"      -> "",
           "data-module"          -> "hmrc-accessible-autocomplete",
           "some-attr1"           -> "1",
           "some-attr2"           -> "2"


### PR DESCRIPTION
`asAccessibleAutocomplete` now requires implicit `Messages`, which could be classed as breaking, but all [current uses](https://github.com/search?q=org%3Ahmrc%20asAccessibleAutocomplete&type=code) I've spot-checked already have one in scope