### PR TITLE
NOJIRA add default entry for optimizely config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 For compatibility information see `govukFrontendVersion` and `hmrcFrontendVersion` in
 [LibDependencies](project/LibDependencies.scala)
 
+## [9.2.0] - 2024-03-22
+
+### Changed
+
+- Added default config entries for optimizely to show that our library supports it, and avoid services using it
+  getting "NotOverriding" config warnings
+
+### Compatible with
+
+- [hmrc/hmrc-frontend v6.4.0](https://github.com/hmrc/hmrc-frontend/releases/tag/v6.4.0)
+- [alphagov/govuk-frontend v5.2.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.2.0)
+
 ## [9.1.0] - 2024-03-19
 
 ### Changed

--- a/play-frontend-hmrc-play-30/src/main/resources/reference.conf
+++ b/play-frontend-hmrc-play-30/src/main/resources/reference.conf
@@ -81,3 +81,7 @@ pta-account-menu {
 }
 
 language.fallback.url = "https://www.gov.uk/government/organisations/hm-revenue-customs"
+
+# used to enable A/B testing experiments from the experimentation team
+optimizely.url = "https://cdn.optimizely.com/js/"
+optimizely.projectId = null

--- a/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/config/TrackingConsentConfigSpec.scala
+++ b/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/config/TrackingConsentConfigSpec.scala
@@ -50,9 +50,21 @@ class TrackingConsentConfigSpec extends AnyWordSpec with Matchers {
       config.optimizelyUrl should equal(None)
     }
 
+    "return None if optimizely.projectId is null" in {
+      implicit val application: Application = buildApp(
+        Map(
+          "optimizely.url"       -> "http://optimizely.com/",
+          "optimizely.projectId" -> null
+        )
+      )
+      val config                            = application.injector.instanceOf[TrackingConsentConfig]
+      config.optimizelyUrl should equal(None)
+    }
+
     "return None if optimizely.url is not defined" in {
       implicit val application: Application = buildApp(
         Map(
+          "optimizely.url"       -> null,
           "optimizely.projectId" -> "1234567"
         )
       )


### PR DESCRIPTION
to stop service getting config warnings when they set their optimizely.projectId only in app-config