### PR TITLE
PLATUI-2972 POC of metatest for generators

### DIFF
--- a/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/GeneratorBaseSpec.scala
+++ b/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/GeneratorBaseSpec.scala
@@ -40,8 +40,9 @@ abstract class GeneratorBaseSpec[T: ClassTag: TypeTag](
     }
   }
 
+  // can't use LazyList because we need to support Scala 2.12
   private def generateInstances(implicit arb: Arbitrary[T]): Seq[T] =
-    LazyList.continually(arb.arbitrary.sample).flatten.take(instanceCount).toList
+    Stream.continually(arb.arbitrary.sample).flatten.take(instanceCount).toList
 
   private val mirror          = runtimeMirror(getClass.getClassLoader)
   private val caseClassFields = typeOf[T].members

--- a/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/GeneratorBaseSpec.scala
+++ b/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/GeneratorBaseSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels
+
+import org.scalacheck.Arbitrary
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
+abstract class GeneratorBaseSpec[T: ClassTag: TypeTag](
+  val ignoredFields: Set[String] = Set.empty,
+  val instanceCount: Int = 100
+)(implicit val arbT: Arbitrary[T])
+    extends AnyWordSpec
+    with Matchers {
+
+  s"Generator for ${typeOf[T]}" should {
+    "generate varying data for all fields" in {
+      val instances       = generateInstances
+      val invariantFields = checkInvariantFieldValues(instances)
+      withClue("Found fields that aren't being randomly generated:") {
+        invariantFields shouldBe empty
+      }
+    }
+  }
+
+  private def generateInstances(implicit arb: Arbitrary[T]): Seq[T] =
+    LazyList.continually(arb.arbitrary.sample).flatten.take(instanceCount).toList
+
+  private val mirror          = runtimeMirror(getClass.getClassLoader)
+  private val caseClassFields = typeOf[T].members
+    .collect {
+      case m: MethodSymbol if m.isCaseAccessor => m
+    }
+
+  private def checkInvariantFieldValues(instances: Seq[T]): Set[String] =
+    caseClassFields.flatMap { field =>
+      val values = instances.map { instance =>
+        val instanceMirror = mirror.reflect(instance)
+        instanceMirror.reflectMethod(field).apply()
+      }
+      if (values.distinct.size == 1) Some(field.name.toString) else None
+    }.toSet -- ignoredFields
+}

--- a/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/footer/GeneratorSpec.scala
+++ b/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/footer/GeneratorSpec.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.footer
+
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.GeneratorBaseSpec
+import Generators.arbFooter
+
+class GeneratorSpec extends GeneratorBaseSpec[Footer](ignoredFields = Set("language"))

--- a/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/header/GeneratorSpec.scala
+++ b/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/header/GeneratorSpec.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.header
+
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.GeneratorBaseSpec
+import Generators.arbHeader
+
+class GeneratorSpec extends GeneratorBaseSpec[Header]


### PR DESCRIPTION
**POC of possible generator metatest**
* minimal boilerplate test class required **for each generator instance**
* base class generates N instances using the generator, then checks for any invariant field values across those instances
* we can also ignore fields we know we don't care about - like the deprecated `language` in the `HmrcFooter`