### PR TITLE
PLATUI-2918 update changelog for changes introduced in v9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,8 +160,8 @@ to
   support. Major breaking release. 
 - Please read the [v9.0.0 release notes](https://github.com/hmrc/play-frontend-hmrc/releases/tag/v9.0.0)
   when uplifting your frontend service, and check that it still works as expected, particularly if using custom Javascript / CSS.
-- If you were previously passing `None` to the `value` property of `SelectItem`, e.g for a placeholder item in a list,
-  you will now need to pass `Some("")` instead.
+- If you were previously passing `None` to the `value` property of `SelectItem` because you need an empty value attribute 
+  (`value=""`, e.g for a placeholder item in a list), you will now need to pass `Some("")` instead, because the default, None, will now not render any value attribute at all - rather than an empty one.
 
 ### Compatible with
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,8 @@ to
   support. Major breaking release. 
 - Please read the [v9.0.0 release notes](https://github.com/hmrc/play-frontend-hmrc/releases/tag/v9.0.0)
   when uplifting your frontend service, and check that it still works as expected, particularly if using custom Javascript / CSS.
+- If you were previously passing `None` to the `value` property of `SelectItem`, e.g for a placeholder item in a list,
+  you will now need to pass `Some("")` instead.
 
 ### Compatible with
 


### PR DESCRIPTION
# Purpose of PR
Changes in v9.0.0 introduced a previously unseen breaking change. If someone tries to implement a SelectItem with a None value, this doesn't work as it previously had done. Instead, passing a value = Some("") will provide the behaviour from versions of play-frontend-hmrc prior to v9.0.0.