### PR TITLE
PLATUI-3210 bump play versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 For compatibility information see `govukFrontendVersion` and `hmrcFrontendVersion` in
 [LibDependencies](project/LibDependencies.scala)
 
+## [10.9.0] - 2024-08-13
+
+### Changed
+
+- Bumped play versions
+- Bumped play-language version
+
+### Compatible with
+
+- [hmrc/hmrc-frontend v6.27.0](https://github.com/hmrc/hmrc-frontend/releases/tag/v6.27.0)
+- [alphagov/govuk-frontend v5.4.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.4.1)
+
+
 ## [10.8.0] - 2024-08-13
 
 ### Changed

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -3,11 +3,11 @@ import sbt._
 object LibDependencies {
   val govukFrontendVersion: String = "5.4.1"
   val hmrcFrontendVersion: String  = "6.27.0"
-  val playLanguageVersion: String  = "8.0.0"
+  val playLanguageVersion: String  = "8.1.0"
 
-  val play28Version = "2.8.21"
-  val play29Version = "2.9.3"
-  val play30Version = "3.0.3"
+  val play28Version = "2.8.22"
+  val play29Version = "2.9.4"
+  val play30Version = "3.0.5"
 
   val shared = Seq(
     "uk.gov.hmrc.webjars"           % "hmrc-frontend"    % hmrcFrontendVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,10 +13,10 @@ addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build" % "3.22.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"   % "2.5.2")
 
 sys.env.get("PLAY_VERSION") match {
-  case Some("2.8") => addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.21")
-  case Some("2.9") => addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.3")
+  case Some("2.8") => addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.22")
+  case Some("2.9") => addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.4")
   case _           =>
     addSbtPlugin(
-      "org.playframework" % "sbt-plugin" % "3.0.4"
+      "org.playframework" % "sbt-plugin" % "3.0.5"
     )
 }


### PR DESCRIPTION
creating this to see if this fails on the PLAY 2.9 build

play-language PR is failing because it can't find sbt-twirl and I want to see if this also can't see the sbt-twirl version that 2.9.4 depends on

https://github.com/hmrc/play-language/pull/51#discussion_r1717057171