### PR TITLE
PLATUI-3297 fix bug with service navigation twirl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 For compatibility information see `govukFrontendVersion` and `hmrcFrontendVersion` in
 [LibDependencies](project/LibDependencies.scala)
 
+## [10.13.0] - 2024-10-02
+
+### Changed
+
+- Tweaked the twirl template for the new `ServiceNavigation` to cover an edge case previously not captured
+
+### Compatible with
+
+- [hmrc/hmrc-frontend v6.31.0](https://github.com/hmrc/hmrc-frontend/releases/tag/v6.31.0)
+- [alphagov/govuk-frontend v5.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.6.0)
+
 ## [10.12.0] - 2024-09-18
 
 ### Changed

--- a/play-frontend-hmrc-play-30/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/GovukServiceNavigation.scala.html
+++ b/play-frontend-hmrc-play-30/src/main/twirl/uk/gov/hmrc/govukfrontend/views/components/GovukServiceNavigation.scala.html
@@ -46,7 +46,7 @@
           }
         </span>
       }
-      @if(navigation.nonEmpty || slots.nonEmpty) {
+      @if(navigation.nonEmpty || slots.exists(slot => slot.navigationStart.nonEmpty || slot.navigationEnd.nonEmpty)) {
         <nav aria-label="@if(navigationLabel.nonEmpty){@navigationLabel}else{@menuButtonText.getOrElse(messages("govuk.serviceNavigation.menuButtonText"))}" class="@{toClasses("govuk-service-navigation__wrapper", navigationClasses)}">
           <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="@navigationId"@if(menuButtonLabel.nonEmpty && menuButtonLabel.get != menuButtonText.getOrElse(messages("govuk.serviceNavigation.menuButtonText"))){ aria-label="@menuButtonLabel"} hidden>
             @menuButtonText.getOrElse(messages("govuk.serviceNavigation.menuButtonText"))

--- a/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/govukfrontend/views/components/GovukServiceNavigationSpec.scala
+++ b/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/govukfrontend/views/components/GovukServiceNavigationSpec.scala
@@ -41,7 +41,7 @@ class GovukServiceNavigationSpec
       output.first().text() shouldBe "my-service"
     }
 
-    "render ServiceNavigationItems correctly" in {
+    "render ServiceNavigationItems correctly in a nav element" in {
       val params = ServiceNavigation(
         navigation = Seq(
           ServiceNavigationItem(
@@ -49,9 +49,10 @@ class GovukServiceNavigationSpec
           )
         )
       )
-      val output = component(params).select(".govuk-service-navigation__text")
+      val output = component(params)
 
-      output.first().text() shouldBe "Cupcakes"
+      output.select(".govuk-service-navigation__text").first().text() shouldBe "Cupcakes"
+      output.toString()                                                 should include("<nav")
     }
 
     "render ServiceNavigationItems with links correctly" in {
@@ -70,7 +71,7 @@ class GovukServiceNavigationSpec
       output.first().attr("href") shouldBe "#"
     }
 
-    "render ServiceNavigation with slotted content out of the nav element" in {
+    "render ServiceNavigation with slotted content with no nav element" in {
       val params = ServiceNavigation(
         serviceName = Some("cupcakes-service"),
         slots = Some(
@@ -85,7 +86,7 @@ class GovukServiceNavigationSpec
       output.toString() shouldNot include("<nav")
     }
 
-    "render ServiceNavigation with slotted content in the nav element" in {
+    "render ServiceNavigation with slotted content with a nav element" in {
       val params = ServiceNavigation(
         serviceName = Some("cupcakes-service"),
         slots = Some(

--- a/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/govukfrontend/views/components/GovukServiceNavigationSpec.scala
+++ b/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/govukfrontend/views/components/GovukServiceNavigationSpec.scala
@@ -70,7 +70,7 @@ class GovukServiceNavigationSpec
       output.first().attr("href") shouldBe "#"
     }
 
-    "render ServiceNavigation with slotted content" in {
+    "render ServiceNavigation with slotted content out of the nav element" in {
       val params = ServiceNavigation(
         serviceName = Some("cupcakes-service"),
         slots = Some(
@@ -79,9 +79,25 @@ class GovukServiceNavigationSpec
           )
         )
       )
-      val output = component(params).select(".my-custom-class")
+      val output = component(params)
 
-      output.first().text() shouldBe "Cupcakes are delicious!"
+      output.select(".my-custom-class").first().text() shouldBe "Cupcakes are delicious!"
+      output.toString() shouldNot include("<nav")
+    }
+
+    "render ServiceNavigation with slotted content in the nav element" in {
+      val params = ServiceNavigation(
+        serviceName = Some("cupcakes-service"),
+        slots = Some(
+          ServiceNavigationSlot(
+            navigationStart = Some("<div class=\"my-custom-class\">Cupcakes are still delicious!</div>")
+          )
+        )
+      )
+      val output = component(params)
+
+      output.select(".my-custom-class").first().text() shouldBe "Cupcakes are still delicious!"
+      output.toString()                                  should include("<nav")
     }
   }
 }


### PR DESCRIPTION
# Purpose of PR
- To fix a bug with the `ServiceNavigation` component twirl template
  - This addresses a discrepancy between our `twirl` template and the `govuk-frontend` `nunjucks` equivalent
  - The slotted content would always provide a `nav` element if any slot was filled, but we only want the `nav` element if a `navigationStart` or `navigationEnd` slot has been filled with content
- Add a new test and update an existing test around this edge case