### PR TITLE
NOJIRA consider how to enable service navigation

### DIFF
--- a/it-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/components/HmrcHeaderIntegrationSpec.scala
+++ b/it-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/components/HmrcHeaderIntegrationSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.hmrcfrontend.views.components
 import uk.gov.hmrc.support.ScalaCheckUtils.ClassifyParams
 import uk.gov.hmrc.hmrcfrontend.support.TemplateIntegrationSpec
 import uk.gov.hmrc.hmrcfrontend.views.html.components._
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.header.HeaderWithServiceNavigation
 
 // We use the below instead of a true arbitrary as the `hmrc-frontend` Nunjucks
 // model of Header is less flexible and specifically requests the href for `cy`
@@ -28,7 +29,10 @@ import uk.gov.hmrc.hmrcfrontend.views.viewmodels.header.Header
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 
 object HmrcHeaderIntegrationSpec
-    extends TemplateIntegrationSpec[Header, HmrcHeader](hmrcComponentName = "hmrcHeader", seed = None) {
+    extends TemplateIntegrationSpec[HeaderWithServiceNavigation, HmrcHeader](
+      hmrcComponentName = "hmrcHeader",
+      seed = None
+    ) {
 
   override def classifiers(header: Header): LazyList[ClassifyParams] =
     (header.homepageUrl.isEmpty, "empty homepageUrl", "non-empty homepageUrl") #::

--- a/play-frontend-hmrc-play-30/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/header/Header.scala
+++ b/play-frontend-hmrc-play-30/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/header/Header.scala
@@ -24,9 +24,11 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.CommonJsonFormats.{htmlReads, 
 import uk.gov.hmrc.govukfrontend.views.viewmodels.phasebanner.PhaseBanner
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{Cy, En, Language, LanguageToggle}
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.userresearchbanner.UserResearchBanner
+import scala.language.implicitConversions
 
 import scala.collection.immutable.SortedMap
 
+// TODO? @deprecated("Use HeaderWithServiceNavigation instead of Header", "11.13.0")
 case class Header(
   homepageUrl: String = "/",
   assetsPath: String = "/assets/images",
@@ -67,6 +69,31 @@ case class Header(
 object Header {
 
   def defaultObject: Header = Header()
+
+  implicit def header2headerWithServiceNavigation(header: Header): HeaderWithServiceNavigation =
+    HeaderWithServiceNavigation(
+      header.homepageUrl,
+      header.assetsPath,
+      header.productName,
+      header.serviceName,
+      header.serviceUrl,
+      header.navigation,
+      header.navigationClasses,
+      header.containerClasses,
+      header.classes,
+      header.attributes,
+      header.language,
+      header.displayHmrcBanner,
+      header.useTudorCrown,
+      header.signOutHref,
+      header.inputLanguageToggle,
+      header.userResearchBanner,
+      header.phaseBanner,
+      header.additionalBannersBlock,
+      header.menuButtonLabel,
+      header.menuButtonText,
+      header.navigationLabel
+    )
 
   implicit def jsonReads: Reads[Header] =
     (

--- a/play-frontend-hmrc-play-30/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/header/HeaderWithServiceNavigation.scala
+++ b/play-frontend-hmrc-play-30/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/viewmodels/header/HeaderWithServiceNavigation.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcfrontend.views.viewmodels.header
+
+import play.api.libs.json.{OWrites, Reads}
+import play.twirl.api.Html
+import uk.gov.hmrc.govukfrontend.views.viewmodels.phasebanner.PhaseBanner
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{Cy, En, Language, LanguageToggle}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.userresearchbanner.UserResearchBanner
+
+import scala.collection.immutable.SortedMap
+
+case class HeaderWithServiceNavigation(
+  homepageUrl: String = "/",
+  assetsPath: String = "/assets/images",
+  productName: Option[String] = None,
+  serviceName: Option[String] = None,
+  serviceUrl: String = "",
+  navigation: Option[Seq[NavigationItem]] = None,
+  navigationClasses: String = "",
+  containerClasses: String = "govuk-width-container",
+  classes: String = "",
+  attributes: Map[String, String] = Map.empty,
+  language: Language = En,
+  displayHmrcBanner: Boolean = false,
+  useTudorCrown: Option[Boolean] = None,
+  signOutHref: Option[String] = None,
+  private val inputLanguageToggle: Option[LanguageToggle] = None,
+  userResearchBanner: Option[UserResearchBanner] = None,
+  phaseBanner: Option[PhaseBanner] = None,
+  additionalBannersBlock: Option[Html] = None,
+  menuButtonLabel: Option[String] = None,
+  menuButtonText: Option[String] = None,
+  navigationLabel: Option[String] = None
+) {
+  // We use this method instead of using the input language toggle directly
+  // as the version in `hmrc-frontend` is less flexible, and sets a default
+  // href for `cy` and `en` as an empty string. This behaviour is mirrored
+  // here both to pass the unit tests and to maintain parity with
+  // `hmrc-frontend`.
+  val languageToggle: Option[LanguageToggle] = inputLanguageToggle match {
+    case Some(x) =>
+      val defaults: SortedMap[Language, String] = SortedMap(En -> "", Cy -> "")
+      Some(LanguageToggle(defaults ++ x.linkMap))
+    case None    => None
+  }
+}
+
+object HeaderWithServiceNavigation {
+  // TODO the bits below would be different in reality since HeaderWithServiceNavigation will
+  // presumably have it's args grouped up, so no map / contramap from Header just used here
+  // for convenience to check my understanding that it this kind of migration would work.
+
+  implicit def jsonReads: Reads[HeaderWithServiceNavigation] =
+    Header.jsonReads.map(Header.header2headerWithServiceNavigation)
+
+  implicit def jsonWrites: OWrites[HeaderWithServiceNavigation] =
+    Header.jsonWrites.contramap(header =>
+      Header(
+        header.homepageUrl,
+        header.assetsPath,
+        header.productName,
+        header.serviceName,
+        header.serviceUrl,
+        header.navigation,
+        header.navigationClasses,
+        header.containerClasses,
+        header.classes,
+        header.attributes,
+        header.language,
+        header.displayHmrcBanner,
+        header.useTudorCrown,
+        header.signOutHref,
+        header.inputLanguageToggle,
+        header.userResearchBanner,
+        header.phaseBanner,
+        header.additionalBannersBlock,
+        header.menuButtonLabel,
+        header.menuButtonText,
+        header.navigationLabel
+      )
+    )
+}

--- a/play-frontend-hmrc-play-30/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/components/HmrcHeader.scala.html
+++ b/play-frontend-hmrc-play-30/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/components/HmrcHeader.scala.html
@@ -21,10 +21,11 @@
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Cy
 @import uk.gov.hmrc.hmrcfrontend.config.TudorCrownConfig
 @import uk.gov.hmrc.hmrcfrontend.views.Utils.nonEmptyStringOrDefault
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.header.HeaderWithServiceNavigation
 
 @this(hmrcBanner: HmrcBanner, hmrcUserResearchBanner: HmrcUserResearchBanner, govukPhaseBanner: GovukPhaseBanner, tudorCrownConfig: TudorCrownConfig)
 
-@(params: Header)
+@(params: HeaderWithServiceNavigation)
 @import params._
 
 @containerClassList = @{
@@ -153,6 +154,7 @@
       </div>
     }
     @additionalBannersBlock
+    @**TODO output serviceNavigation wherever it should go**@
 </header>
 
 @serviceNameLinkOrSpan(serviceName: Option[String], serviceUrl: String) = {

--- a/play-frontend-hmrc-play-30/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcStandardHeader.scala.html
+++ b/play-frontend-hmrc-play-30/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcStandardHeader.scala.html
@@ -17,6 +17,7 @@
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcHeader
 @import uk.gov.hmrc.hmrcfrontend.views.Aliases.{Cy, En, Header, UserResearchBanner}
 @import uk.gov.hmrc.govukfrontend.views.Aliases.PhaseBanner
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.servicenavigation.ServiceNavigation
 
 @this(hmrcHeader: HmrcHeader)
 
@@ -28,11 +29,16 @@
   phaseBanner: Option[PhaseBanner] = None,
   displayHmrcBanner: Boolean = false,
   additionalBannersBlock: Option[Html] = None,
-  containerClasses: String = Header.defaultObject.containerClasses
+  containerClasses: String = Header.defaultObject.containerClasses,
+  serviceNavigation: Option[ServiceNavigation] = null // null used as sentinel to allow turning it off even if enabled in config
 )(implicit messages: Messages, request: RequestHeader)
+@**
+here we could check if serviceNavigation == null and if it does, grab the default from config, or else just use the
+supplied serviceNavigation - where using null isn't great but it's only used as an internal thing never exposed to users
+**@
 @defining("service.name") { serviceNameKey =>
   @defining(if(messages.isDefinedAt(serviceNameKey)) Some(messages(serviceNameKey)) else None) { serviceNameFromMessages =>
-    @hmrcHeader(Header(
+    @hmrcHeader(Header( // TODO change to HeaderWithServiceNavigation
       homepageUrl = messages("header.govuk.url"),
       serviceName = serviceName.orElse(serviceNameFromMessages),
       serviceUrl = serviceUrl.getOrElse(""),

--- a/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/components/HmrcHeaderSpec.scala
+++ b/play-frontend-hmrc-play-30/src/test/scala/uk/gov/hmrc/hmrcfrontend/views/components/HmrcHeaderSpec.scala
@@ -20,10 +20,11 @@ package components
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.hmrcfrontend.views.html.components._
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.header.HeaderWithServiceNavigation
 
 import scala.util.Try
 
-class HmrcHeaderSpec extends TemplateUnitSpec[Header, HmrcHeader]("hmrcHeader") {
+class HmrcHeaderSpec extends TemplateUnitSpec[HeaderWithServiceNavigation, HmrcHeader]("hmrcHeader") {
 
   def buildAnotherApp(properties: Map[String, String] = Map.empty): Application =
     new GuiceApplicationBuilder()


### PR DESCRIPTION
was just looking at ways to migrate off of current Header if we do want to add some options for serviceNavigation to it since we're basically at the 22 value limit for case classes so need to refactor

didn't want to suggest we do what we did with hmrc standard layout again - where we created a new component and delegated as that seemed like it involved work for teams that was confusing

this approach instead is changing input param and having an implicit conversion from old Header to new input param type so people using Header don't have to make any changes and we just have one template to maintain

~not sure exactly how to enable it via config at this point - some nuance to how it needs to be possible to enable it, future spikes, but wanted to create this as a prompt for that work~

added some stuff around how we could enable it via config by using null as a sentinel value (so can be overridden)