### PR TITLE
NOJIRA example of propagating service nav usage

### DIFF
--- a/play-frontend-hmrc-play-30/src/main/resources/reference.conf
+++ b/play-frontend-hmrc-play-30/src/main/resources/reference.conf
@@ -92,3 +92,5 @@ play.assets.cache."/public/lib/hmrc-frontend/"="public, max-age=3600"
 # used to enable A/B testing experiments from the experimentation team
 optimizely.url = "https://cdn.optimizely.com/js/"
 optimizely.projectId = null
+
+play.modules.enabled += "uk.gov.hmrc.hmrcfrontend.config.DefaultServiceNavConfigModule"

--- a/play-frontend-hmrc-play-30/src/main/scala/uk/gov/hmrc/hmrcfrontend/config/AccessibilityStatementConfig.scala
+++ b/play-frontend-hmrc-play-30/src/main/scala/uk/gov/hmrc/hmrcfrontend/config/AccessibilityStatementConfig.scala
@@ -22,7 +22,7 @@ import javax.inject.Inject
 import play.api.Configuration
 import play.api.mvc.RequestHeader
 
-class AccessibilityStatementConfig @Inject() (config: Configuration) {
+class AccessibilityStatementConfig @Inject() (config: Configuration, serviceNavUsage: ServiceNavigationConfig) {
   val platformHost: Option[String]                      =
     config.getOptional[String]("platform.frontend.host")
   val accessibilityStatementHost: Option[String]        =
@@ -37,7 +37,7 @@ class AccessibilityStatementConfig @Inject() (config: Configuration) {
       host        <- accessibilityStatementHost
       path        <- accessibilityStatementPath
       servicePath <- accessibilityStatementServicePath
-    } yield s"$host$path$servicePath$query"
+    } yield serviceNavUsage.propagateViaQueryParam(s"$host$path$servicePath$query")
 
   private def query(implicit request: RequestHeader): String = {
     val referrerUrl = URLEncoder.encode(s"${platformHost.getOrElse("")}${pathWithQuerystring(request)}", "UTF-8")

--- a/play-frontend-hmrc-play-30/src/main/scala/uk/gov/hmrc/hmrcfrontend/config/ServiceNavigationConfig.scala
+++ b/play-frontend-hmrc-play-30/src/main/scala/uk/gov/hmrc/hmrcfrontend/config/ServiceNavigationConfig.scala
@@ -17,15 +17,98 @@
 package uk.gov.hmrc.hmrcfrontend.config
 
 import play.api.Configuration
+import play.api.mvc.RequestHeader
+import play.api.inject._
+import play.api.libs.typedmap.TypedKey
+import ServiceNavCanBeControlledByRequestAttr.UseServiceNav
+import ServiceNavCanBeControlledByQueryParam.useServiceNavQueryParam
+import ServiceNavCanBeControlledByConfig.useServiceNavConfigKey
 
-import javax.inject.Inject
+import java.net.URI
+import scala.util.Try
+import javax.inject.{Inject, Singleton}
 
-class ServiceNavigationConfig @Inject() (config: Configuration) {
+trait ServiceNavigationConfig {
+  def propagateViaQueryParam(href: String)(implicit request: RequestHeader): String = {
+    def queryParamAlreadySet(uri: URI): Boolean =
+      Option(uri.getRawQuery).exists(_.split("&").exists(_.startsWith(s"$useServiceNavQueryParam=")))
 
-  /*
-  Service Navigation is not hidden by the feature flag, but
-  we are adding this flag to allows enabling Service Navigation without any changes
-  Once this flag is set to true, we will add Service Navigation to the header, move service name and language toggle
-   */
-  val forceServiceNavigation: Boolean = config.get[Boolean]("play-frontend-hmrc.forceServiceNavigation")
+    Try(new URI(href))
+      .collect {
+        case uri if !queryParamAlreadySet(uri) =>
+          val queryParam = s"$useServiceNavQueryParam=$forceServiceNavigation"
+          new URI(
+            uri.getScheme,
+            uri.getRawAuthority,
+            uri.getRawPath,
+            uri.getRawQuery match {
+              case null | ""   => queryParam
+              case queryString => s"$queryString&$queryParam"
+            },
+            uri.getRawFragment
+          ).toString
+      }
+      .getOrElse(href)
+  }
+
+  def forceServiceNavigation(implicit request: RequestHeader): Boolean // if some service nav not provided
 }
+
+@Singleton
+class ServiceNavCanBeControlledByRequestAttr @Inject() (config: Configuration) extends ServiceNavigationConfig {
+  // To allow incremental migration of services while maintaining accessibility
+
+  private val determinedByConfig: Boolean = config.get[Boolean](useServiceNavConfigKey)
+
+  override def forceServiceNavigation(implicit request: RequestHeader): Boolean =
+    request.attrs.get(UseServiceNav).getOrElse(determinedByConfig)
+}
+
+object ServiceNavCanBeControlledByRequestAttr {
+  val UseServiceNav: TypedKey[Boolean] = TypedKey[Boolean]("UseServiceNav")
+}
+
+@Singleton
+class ServiceNavCanBeControlledByQueryParam @Inject() (config: Configuration) extends ServiceNavigationConfig {
+  // To allow incremental migration of services while maintaining accessibility
+
+  private val determinedByConfig: Boolean = config.get[Boolean](useServiceNavConfigKey)
+
+  override def forceServiceNavigation(implicit request: RequestHeader): Boolean =
+    request.queryString
+      .get(useServiceNavQueryParam)
+      .map(!_.contains("false"))
+      .getOrElse(determinedByConfig)
+}
+
+object ServiceNavCanBeControlledByQueryParam {
+  val useServiceNavQueryParam = "useServiceNav"
+}
+
+@Singleton
+class ServiceNavCanBeControlledByConfig @Inject() (config: Configuration) extends ServiceNavigationConfig {
+  // To make it easier to coordinate releases during migration
+
+  private val determinedByConfig = config.get[Boolean](useServiceNavConfigKey)
+
+  override def forceServiceNavigation(implicit request: RequestHeader): Boolean = determinedByConfig
+}
+
+object ServiceNavCanBeControlledByConfig {
+  val useServiceNavConfigKey = "play-frontend-hmrc.forceServiceNavigation"
+}
+
+class ServiceNavCanBeControlledByRequestAttrModule
+    extends SimpleModule(
+      bind[ServiceNavigationConfig].to[ServiceNavCanBeControlledByRequestAttr]
+    )
+
+class ServiceNavCanBeControlledByQueryParamModule
+    extends SimpleModule(
+      bind[ServiceNavigationConfig].to[ServiceNavCanBeControlledByQueryParam]
+    )
+
+class DefaultServiceNavConfigModule
+    extends SimpleModule(
+      bind[ServiceNavigationConfig].to[ServiceNavCanBeControlledByConfig]
+    )

--- a/play-frontend-hmrc-play-30/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcFooterItems.scala
+++ b/play-frontend-hmrc-play-30/src/main/scala/uk/gov/hmrc/hmrcfrontend/views/config/HmrcFooterItems.scala
@@ -20,9 +20,12 @@ import javax.inject.Inject
 import play.api.i18n.Messages
 import play.api.mvc.RequestHeader
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.footer.FooterItem
-import uk.gov.hmrc.hmrcfrontend.config.AccessibilityStatementConfig
+import uk.gov.hmrc.hmrcfrontend.config.{AccessibilityStatementConfig, ServiceNavigationConfig}
 
-class HmrcFooterItems @Inject() (accessibilityStatementConfig: AccessibilityStatementConfig) {
+class HmrcFooterItems @Inject() (
+  accessibilityStatementConfig: AccessibilityStatementConfig,
+  serviceNavUsage: ServiceNavigationConfig
+) {
   def get(implicit messages: Messages, request: RequestHeader): Seq[FooterItem] =
     getWithAccessibilityStatementUrl(None)
 
@@ -30,10 +33,10 @@ class HmrcFooterItems @Inject() (accessibilityStatementConfig: AccessibilityStat
     accessibilityStatementUrl: Option[String]
   )(implicit messages: Messages, request: RequestHeader): Seq[FooterItem] =
     Seq(
-      footerItemForKey("cookies"),
-      accessibilityLink(accessibilityStatementUrl),
-      footerItemForKey("privacy"),
-      footerItemForKey("termsConditions"),
+      propagatingServiceNavUsageViaQueryParam(footerItemForKey("cookies")),
+      propagatingServiceNavUsageViaQueryParam(accessibilityLink(accessibilityStatementUrl)),
+      propagatingServiceNavUsageViaQueryParam(footerItemForKey("privacy")),
+      propagatingServiceNavUsageViaQueryParam(footerItemForKey("termsConditions")),
       footerItemForKey("govukHelp"),
       footerItemForKey("contact"),
       footerItemForKey("welshHelp", attributes = Map("lang" -> "cy", "hreflang" -> "cy"))
@@ -54,6 +57,15 @@ class HmrcFooterItems @Inject() (accessibilityStatementConfig: AccessibilityStat
         text = Some(messages(s"footer.$item.text")),
         href = Some(messages(s"footer.$item.url")),
         attributes = attributes
+      )
+    )
+
+  private def propagatingServiceNavUsageViaQueryParam(
+    footerItem: Option[FooterItem]
+  )(implicit request: RequestHeader): Option[FooterItem] =
+    footerItem.map(item =>
+      item.copy(
+        href = item.href.map(serviceNavUsage.propagateViaQueryParam)
       )
     )
 }

--- a/play-frontend-hmrc-play-30/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/components/HmrcReportTechnicalIssue.scala.html
+++ b/play-frontend-hmrc-play-30/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/components/HmrcReportTechnicalIssue.scala.html
@@ -15,11 +15,12 @@
  *@
 
 @import uk.gov.hmrc.hmrcfrontend.views.html.components._
+@import uk.gov.hmrc.hmrcfrontend.config.ServiceNavigationConfig
+@import uk.gov.hmrc.hmrcfrontend.config.ServiceNavCanBeControlledByQueryParam.useServiceNavQueryParam
 
-@this()
+@this(serviceNavigationConfig: ServiceNavigationConfig)
 
-
-@(params: ReportTechnicalIssue)
+@(params: ReportTechnicalIssue)(implicit request: RequestHeader)
 @import params._
 @defining(if(serviceId.nonEmpty) serviceId else serviceCode) { service =>
   <a lang="@params.language.code"
@@ -27,6 +28,6 @@
     class="@toClasses("govuk-link hmrc-report-technical-issue ", classes.getOrElse(""))"
     @if(params.referrerUrl.exists(_.nonEmpty)) { rel="noreferrer noopener" }
     target="_blank"
-    href="@params.baseUrl.getOrElse("")/contact/report-technical-problem?service=@urlEncode(service)@params.referrerUrl.filter(_.nonEmpty).map{ url =>&amp;referrerUrl=@urlEncode(url)}"
+    href="@params.baseUrl.getOrElse("")/contact/report-technical-problem?service=@urlEncode(service)@params.referrerUrl.filter(_.nonEmpty).map{ url =>&amp;referrerUrl=@urlEncode(url)}@if(serviceNavigationConfig.forceServiceNavigation){&@useServiceNavQueryParam=true}"
   >@if(params.language.code == "cy") {A yw’r dudalen hon yn gweithio’n iawn? (yn agor tab newydd)} else {Is this page not working properly? (opens in new tab)}</a>
 }

--- a/play-frontend-hmrc-play-30/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcLanguageSelectHelper.scala.html
+++ b/play-frontend-hmrc-play-30/src/main/twirl/uk/gov/hmrc/hmrcfrontend/views/helpers/HmrcLanguageSelectHelper.scala.html
@@ -22,7 +22,7 @@
 
 @this(hmrcLanguageSelect: HmrcLanguageSelect, serviceNavigationConfig: ServiceNavigationConfig)
 
-@()(implicit messages: Messages)
+@()(implicit messages: Messages, request: RequestHeader)
 @import SupportedLanguagesConfig._
 
 @if(!serviceNavigationConfig.forceServiceNavigation) {


### PR DESCRIPTION
needed to sketch it out to think about it

example of then consuming propagated service nav usage from url

https://github.com/hmrc/help-frontend/pull/172/changes
https://github.com/hmrc/contact-frontend/pull/367

some of this might not be needed but I had to think it through!

some other areas to explore maybe for propagating service nav usage through urls

- ask people to override the urls they use in their messages to add url param onto the end, services like address lookup would need to build urls themselves but they might already do that so no problem
- add something to the api of components that display links that we might want to propagate service nav state on - something like "usingServiceNav: Boolean" that will then append query param to links, don't like the idea of temporary api change for something like this myself, which was why I needed to think this through a bit, because it's easy to just set service nav ourselves based on request when using hmrc standard layout, but getting the other links to propagate service nav felt hard to do

going to be writing up ticket to write a problem statement, this is just me doing a bit of advanced thinking to get it in my head because it feels a bit "do it now" 🙏 

this doesn't propagate via query param of report technical problem at the moment because that url is hard to add because of how hard coded the template is :oof: